### PR TITLE
Various OSCORE improvements

### DIFF
--- a/examples/oscore/Makefile
+++ b/examples/oscore/Makefile
@@ -14,6 +14,7 @@ ifeq ($(TARGET),native)
 	MODULES_REL += ./resources-plugtest
 endif
 MODULES_REL += ./resources
+MODULES_REL += ../coap/coap-example-server/resources
 MODULES_REL += $(TARGET)
 
 CONTIKI_TARGET_SOURCEFILES += plugtest_resources.c

--- a/examples/oscore/oscore-example-client.c
+++ b/examples/oscore/oscore-example-client.c
@@ -103,14 +103,8 @@ PROCESS_THREAD(er_example_client, ev, data)
   static coap_endpoint_t server_ep;
 
   coap_endpoint_parse(SERVER_EP, strlen(SERVER_EP), &server_ep);
-  
-  /* receives all CoAP messages */
-  coap_engine_init();
 
   #ifdef WITH_OSCORE
-  /* Initiate the OSCORE client, this includes storage for OSCORE-Security-Contexts. */
-  oscore_init_client();
- 
   /*Derive an OSCORE-Security-Context. */
   static oscore_ctx_t *context;
   context = oscore_derive_ctx(master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);

--- a/examples/oscore/oscore-example-client.c
+++ b/examples/oscore/oscore-example-client.c
@@ -106,16 +106,14 @@ PROCESS_THREAD(er_example_client, ev, data)
 
   #ifdef WITH_OSCORE
   /*Derive an OSCORE-Security-Context. */
-  static oscore_ctx_t *context;
-  context = oscore_derive_ctx(master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
-  if(!context){
-	LOG_ERR("Could not create OSCORE Security Context!\n");
-  }
+  static oscore_ctx_t context;
+  oscore_derive_ctx(&context, master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
+
   /* Set the association between a remote URL and a security contect. When sending a message the specified context will be used to 
    * protect the message. Note that this can be done on a resource-by-resource basis. Thus any requests to .well-known/core will not 
    * be OSCORE protected.*/  
-  oscore_ep_ctx_set_association(&server_ep, service_urls[1], context);
-  oscore_ep_ctx_set_association(&server_ep, service_urls[2], context);
+  oscore_ep_ctx_set_association(&server_ep, service_urls[1], &context);
+  oscore_ep_ctx_set_association(&server_ep, service_urls[2], &context);
 
   #endif /* WITH_OSCORE */
 

--- a/examples/oscore/oscore-example-observe-client.c
+++ b/examples/oscore/oscore-example-observe-client.c
@@ -142,8 +142,7 @@ PROCESS_THREAD(er_example_observe_client, ev, data)
 
   /* store server address in server_ipaddr */
   SERVER_NODE(server_ipaddr);
-  /* receives all CoAP messages */
-  coap_init_engine();
+
   /* init timer and button (if available) */
   etimer_set(&et, TOGGLE_INTERVAL * CLOCK_SECOND);
 #if PLATFORM_HAS_BUTTON

--- a/examples/oscore/oscore-example-server.c
+++ b/examples/oscore/oscore-example-server.c
@@ -113,11 +113,8 @@ PROCESS_THREAD(er_example_server, ev, data)
 
   #ifdef WITH_OSCORE
   /*Derive an OSCORE-Security-Context. */
-  static oscore_ctx_t *context;
-  context = oscore_derive_ctx(master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
-  if(!context){
-	printf("Could not create OSCORE Security Context!\n");
-  }
+  static oscore_ctx_t context;
+  oscore_derive_ctx(&context, master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
 
   uint8_t key_id[] = { 0x63, 0x6C, 0x69, 0x65, 0x6E, 0x74 };
   oscore_ctx_t *ctx;

--- a/examples/oscore/oscore-example-server.c
+++ b/examples/oscore/oscore-example-server.c
@@ -111,13 +111,7 @@ PROCESS_THREAD(er_example_server, ev, data)
   printf("PAN ID: 0x%04X\n", IEEE802154_PANID);
 #endif
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
-
   #ifdef WITH_OSCORE
-  /* Initiate the OSCORE server, this includes storage for OSCORE-Security-Contexts. */
-  oscore_init_server();
-
   /*Derive an OSCORE-Security-Context. */
   static oscore_ctx_t *context;
   context = oscore_derive_ctx(master_secret, 35, NULL, 0, 10, sender_id, 6, receiver_id, 6, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);

--- a/examples/oscore/oscore-plugtest-client.c
+++ b/examples/oscore/oscore-plugtest-client.c
@@ -91,18 +91,16 @@ PROCESS_THREAD(er_example_client, ev, data)
   coap_endpoint_parse(SERVER_EP, strlen(SERVER_EP), &server_ep);
 
   #ifdef WITH_OSCORE
-  static oscore_ctx_t *context;
-  context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 0, receiver_id, 1, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
-  if(!context){
-	printf("Could not create OSCORE Security Context!\n");
-  }
+  static oscore_ctx_t context;
+  oscore_derive_ctx(&context, master_secret, 16, salt, 8, 10, sender_id, 0, receiver_id, 1, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
+
   uint8_t ret = 0;
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[2], context);
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[3], context);
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[4], context);
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[5], context);
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[6], context);
-  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[7], context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[2], &context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[3], &context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[4], &context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[5], &context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[6], &context);
+  ret += oscore_ep_ctx_set_association(&server_ep, service_urls[7], &context);
   if( ret != 6) {
 	 printf("Not all URIs associated with contexts!\n");
   } 
@@ -171,7 +169,7 @@ PROCESS_THREAD(er_example_client, ev, data)
           break; 
 	case 16:
 	  //Associate /oscore/hello/coap with context to provide encryption 
-          if(!oscore_ep_ctx_set_association(&server_ep, service_urls[1], context)){
+          if(!oscore_ep_ctx_set_association(&server_ep, service_urls[1], &context)){
 		  printf("EP ERROR!\n");
 	  }
 	  test16_a(request);

--- a/examples/oscore/oscore-plugtest-client.c
+++ b/examples/oscore/oscore-plugtest-client.c
@@ -90,12 +90,7 @@ PROCESS_THREAD(er_example_client, ev, data)
 
   coap_endpoint_parse(SERVER_EP, strlen(SERVER_EP), &server_ep);
 
-  /* receives all CoAP messages */
-  coap_engine_init();
-
   #ifdef WITH_OSCORE
-  oscore_init_client();
-
   static oscore_ctx_t *context;
   context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 0, receiver_id, 1, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
   if(!context){

--- a/examples/oscore/oscore-plugtest-server.c
+++ b/examples/oscore/oscore-plugtest-server.c
@@ -87,12 +87,9 @@ PROCESS_THREAD(plugtest_server, ev, data)
 
   PRINTF("OSCORE Plugtests Server\n");
 
-  static oscore_ctx_t *context;
-  context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
-  //context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, id_context, 8, OSCORE_DEFAULT_REPLAY_WINDOW);
-  if(!context){
-        printf("Could not create OSCORE Security Context!\n");
-  }
+  static oscore_ctx_t context;
+  oscore_derive_ctx(&context, master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
+  //oscore_derive_ctx(&context, master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, id_context, 8, OSCORE_DEFAULT_REPLAY_WINDOW);
 
   uint8_t *key_id = NULL;
   oscore_ctx_t *ctx;

--- a/examples/oscore/oscore-plugtest-server.c
+++ b/examples/oscore/oscore-plugtest-server.c
@@ -87,11 +87,6 @@ PROCESS_THREAD(plugtest_server, ev, data)
 
   PRINTF("OSCORE Plugtests Server\n");
 
-  /* Initialize the REST engine. */
-  coap_engine_init();
-  
-  oscore_init_server();
-
   static oscore_ctx_t *context;
   context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, NULL, 0, OSCORE_DEFAULT_REPLAY_WINDOW);
   //context = oscore_derive_ctx(master_secret, 16, salt, 8, 10, sender_id, 1, receiver_id, 0, id_context, 8, OSCORE_DEFAULT_REPLAY_WINDOW);

--- a/examples/oscore/resources/plugtest_resources.c
+++ b/examples/oscore/resources/plugtest_resources.c
@@ -346,8 +346,8 @@ void test12_a(coap_message_t* request){
 	  printf("COULD NOT FIND CONTEXT!\n");
   }
 
-  security_context->sender_context->sender_id = false_sender_id;
-  security_context->sender_context->sender_id_len = false_sender_id_len;
+  security_context->sender_context.sender_id = false_sender_id;
+  security_context->sender_context.sender_id_len = false_sender_id_len;
   printf("Test 12a: Sending!\n");
 }
 
@@ -368,8 +368,8 @@ void test12_a_handler(void* response){
     failed_tests++;
   }
 
-  security_context->sender_context->sender_id = real_sender_id;
-  security_context->sender_context->sender_id_len = real_sender_id_len;
+  security_context->sender_context.sender_id = real_sender_id;
+  security_context->sender_context.sender_id_len = real_sender_id_len;
 } 
 
 void test13_a(coap_message_t* request){
@@ -379,7 +379,7 @@ void test13_a(coap_message_t* request){
 
   coap_set_oscore(request);
   
-  memcpy(security_context->sender_context->sender_key, false_sender_key, 16);
+  memcpy(security_context->sender_context.sender_key, false_sender_key, 16);
   printf("Test 13a: Sending!\n");
 }
 
@@ -399,7 +399,7 @@ void test13_a_handler(void* response){
 
     failed_tests++;
   }
-  memcpy(security_context->sender_context->sender_key, real_sender_key, 16);
+  memcpy(security_context->sender_context.sender_key, real_sender_key, 16);
 }
 
 void test14_a(coap_message_t* request){
@@ -409,7 +409,7 @@ void test14_a(coap_message_t* request){
 
   coap_set_oscore(request);
   
-  memcpy(security_context->recipient_context->recipient_key, false_recipient_key, 16);
+  memcpy(security_context->recipient_context.recipient_key, false_recipient_key, 16);
   printf("Test 14a: Sending!\n");
 }
 
@@ -429,7 +429,7 @@ void test14_a_handler(void* response){
     printf("Got : %d\n", ((coap_message_t*)response)->code);
     failed_tests++;
   }
-  memcpy(security_context->recipient_context->recipient_key, real_recipient_key, 16);
+  memcpy(security_context->recipient_context.recipient_key, real_recipient_key, 16);
 }
 
 void test15_a(coap_message_t* request){
@@ -439,8 +439,8 @@ void test15_a(coap_message_t* request){
 
   coap_set_oscore(request);
   
-  real_sender_seq = security_context->sender_context->seq;
-  security_context->sender_context->seq = 1;
+  real_sender_seq = security_context->sender_context.seq;
+  security_context->sender_context.seq = 1;
   printf("Test 15a: Sending!\n");
 }
 
@@ -460,7 +460,7 @@ void test15_a_handler(void* response){
 
     failed_tests++;
   }
-  security_context->sender_context->seq = real_sender_seq;
+  security_context->sender_context.seq = real_sender_seq;
 }
 
 void test16_a(coap_message_t* request){

--- a/os/contiki-main.c
+++ b/os/contiki-main.c
@@ -65,6 +65,9 @@
 #define LOG_MODULE "Main"
 #define LOG_LEVEL LOG_LEVEL_MAIN
 /*---------------------------------------------------------------------------*/
+#define STRINGIFY(a) STRINGIFY_(a)
+#define STRINGIFY_(a) #a
+/*---------------------------------------------------------------------------*/
 int
 #if PLATFORM_MAIN_ACCEPTS_ARGS
 main(int argc, char **argv)
@@ -125,6 +128,14 @@ main(void)
     LOG_INFO_("\n");
   }
 #endif /* NETSTACK_CONF_WITH_IPV6 */
+
+#ifdef AES_128_CONF
+  LOG_INFO("AES_128_CONF Driver: " STRINGIFY(AES_128_CONF) "\n");
+#endif
+#ifdef CCM_STAR_CONF
+  LOG_INFO("CCM_STAR_CONF Driver: " STRINGIFY(CCM_STAR_CONF) "\n");
+#endif
+
 
   platform_init_stage_three();
 

--- a/os/net/app-layer/coap/Makefile.coap
+++ b/os/net/app-layer/coap/Makefile.coap
@@ -3,7 +3,14 @@ MAKE_WITH_OSCORE ?= 0
 
 
 ifeq ($(MAKE_WITH_OSCORE),1)
- MODULES += os/net/security/tinydtls/sha2
+
+ TINYDTLS_PATH := os/net/security/tinydtls
+
+ ifeq (${wildcard $(CONTIKI)/$(TINYDTLS_PATH)/Makefile},)
+  ${error Could not find the tinyDTLS submodule. Please run "git submodule update --init" and try again}
+ endif
+
+ MODULES += $(TINYDTLS_PATH)/sha2
  CFLAGS += -DSHA2_USE_INTTYPES_H -DWITH_SHA256 -DHAVE_ASSERT_H
  
  CFLAGS += -DWITH_OSCORE=1

--- a/os/net/app-layer/coap/coap-blocking-api.c
+++ b/os/net/app-layer/coap/coap-blocking-api.c
@@ -93,28 +93,28 @@ PT_THREAD(coap_blocking_request
 
   do {
     request->mid = coap_get_mid();
-    #ifdef WITH_OSCORE
+#ifdef WITH_OSCORE
 
     const char *uri;
     oscore_ctx_t *context = NULL;
     if(coap_get_header_uri_path(request, &uri)){
       context = oscore_get_context_from_ep(remote_ep, uri);
     } else {
-  	printf("NO URI PATH\n");
+      LOG_DBG("NO URI PATH\n");
     }
 
     if(context){
-	printf("OSCORE found!\n");
-	coap_set_oscore(request);
-	request->security_context = context;
- 	//TODO maybe an if and random token should be added here
-	uint8_t token[2] = {0xA, 0xA};
-    	coap_set_token(request, token, 2);
+      LOG_DBG("OSCORE found!\n");
+      coap_set_oscore(request);
+      request->security_context = context;
+      //TODO maybe an if and random token should be added here
+      const uint8_t token[2] = {0xA, 0xA};
+      coap_set_token(request, token, sizeof(token));
     } else {
-	printf("NO OSCORE!\n");
-	printf("URL %s \n", uri);
+      LOG_DBG("NO OSCORE!\n");
+      LOG_DBG("URL %s \n", uri);
     }
-    #endif /* WITH_OSCORE */
+#endif /* WITH_OSCORE */
     if((state->transaction = coap_new_transaction(request->mid, remote_ep))) {
       state->transaction->callback = coap_blocking_request_callback;
       state->transaction->callback_data = blocking_state;

--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -167,20 +167,15 @@ coap_send_request(coap_callback_request_state_t *callback_state, coap_endpoint_t
   oscore_ctx_t *context = NULL;
   if(coap_get_header_uri_path(request, &uri)){
     context = oscore_get_context_from_ep(endpoint, uri);
+    if(context){
+      coap_set_oscore(request);
+      request->security_context = context;
+      //TODO maybe an if and random token should be added here
+      const uint8_t token[2] = {0xA, 0xA};
+      coap_set_token(request, token, sizeof(token));
+    }
   } else {
-    LOG_DBG("NO URI PATH\n");
-  }
-
-  if(context){
-    LOG_DBG("OSCORE found!\n");
-    coap_set_oscore(request);
-    request->security_context = context;
-    //TODO maybe an if and random token should be added here
-    const uint8_t token[2] = {0xA, 0xA};
-    coap_set_token(request, token, sizeof(token));
-  } else {
-    LOG_DBG("NO OSCORE!\n");
-    LOG_DBG("URL %s \n", uri);
+    LOG_WARN("OSCORE: No URI to fetch context from\n");
   }
 #endif /* WITH_OSCORE */
 

--- a/os/net/app-layer/coap/coap-callback-api.c
+++ b/os/net/app-layer/coap/coap-callback-api.c
@@ -162,6 +162,28 @@ coap_send_request(coap_callback_request_state_t *callback_state, coap_endpoint_t
   state->remote_endpoint = endpoint;
   callback_state->callback = callback;
 
+#ifdef WITH_OSCORE
+  const char *uri;
+  oscore_ctx_t *context = NULL;
+  if(coap_get_header_uri_path(request, &uri)){
+    context = oscore_get_context_from_ep(endpoint, uri);
+  } else {
+    LOG_DBG("NO URI PATH\n");
+  }
+
+  if(context){
+    LOG_DBG("OSCORE found!\n");
+    coap_set_oscore(request);
+    request->security_context = context;
+    //TODO maybe an if and random token should be added here
+    const uint8_t token[2] = {0xA, 0xA};
+    coap_set_token(request, token, sizeof(token));
+  } else {
+    LOG_DBG("NO OSCORE!\n");
+    LOG_DBG("URL %s \n", uri);
+  }
+#endif /* WITH_OSCORE */
+
   return progress_request(callback_state);
 }
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap-constants.h
+++ b/os/net/app-layer/coap/coap-constants.h
@@ -116,6 +116,7 @@ typedef enum {
   PACKET_SERIALIZATION_ERROR,
 
   /* OSCORE errors */
+  OSCORE_MISSING_CONTEXT,
   OSCORE_DECRYPTION_ERROR,
   /* Erbium hooks */
   MANUAL_RESPONSE,

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -428,6 +428,10 @@ coap_engine_init(void)
 
   coap_transport_init();
   coap_init_connection();
+
+#ifdef WITH_OSCORE
+  oscore_init();
+#endif
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -142,6 +142,10 @@ call_service(coap_message_t *request, coap_message_t *response,
 /* the discover resource is automatically included for CoAP */
 extern coap_resource_t res_well_known_core;
 
+#ifdef WITH_OSCORE
+extern void oscore_missing_security_context(const coap_endpoint_t *src);
+#endif
+
 /*---------------------------------------------------------------------------*/
 /*- Internal API ------------------------------------------------------------*/
 /*---------------------------------------------------------------------------*/
@@ -371,6 +375,12 @@ coap_receive(const coap_endpoint_t *src,
         callback(callback_data, message);
       }
     }
+
+  } else if(coap_status_code == OSCORE_MISSING_CONTEXT) {
+    LOG_WARN("OSCORE cannot decrypt, missing context!\n");
+
+    // Need to inform receivers of failed decryption
+    oscore_missing_security_context(src);
 
   } else {
     coap_message_type_t reply_type = COAP_TYPE_ACK;

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -389,6 +389,10 @@ coap_receive(const coap_endpoint_t *src,
       oscore_missing_security_context(src);
 
       coap_status_code = UNAUTHORIZED_4_01;
+
+      // TODO: this return needs to be removed so that a
+      // UNAUTHORIZED_4_01 is sent if a context is unavailable.
+      return coap_status_code;
     }
 #endif /* WITH_OSCORE */
 

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -380,14 +380,18 @@ coap_receive(const coap_endpoint_t *src,
         callback(callback_data, message);
       }
     }
-
-  } else if(coap_status_code == OSCORE_MISSING_CONTEXT) {
-    LOG_WARN("OSCORE cannot decrypt, missing context!\n");
-
-    // Need to inform receivers of failed decryption
-    oscore_missing_security_context(src);
-
   } else {
+#ifdef WITH_OSCORE
+    if (coap_status_code == OSCORE_MISSING_CONTEXT) {
+      LOG_WARN("OSCORE cannot decrypt, missing context!\n");
+
+      /* Need to inform receivers of failed decryption */
+      oscore_missing_security_context(src);
+
+      coap_status_code = UNAUTHORIZED_4_01;
+    }
+#endif /* WITH_OSCORE */
+
     coap_message_type_t reply_type = COAP_TYPE_ACK;
 
     LOG_WARN("ERROR %u: %s\n", coap_status_code, coap_error_message);

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -192,15 +192,16 @@ coap_receive(const coap_endpoint_t *src,
                             coap_get_mid());
           /* mirror token */
         }
-        #ifdef WITH_OSCORE 
-	if(coap_is_option(message, COAP_OPTION_OSCORE)){
-	  coap_set_oscore(response);
-	  if(message->security_context == NULL){
-		  printf("context is NULL\n");
-	  }
+
+#ifdef WITH_OSCORE 
+        if(coap_is_option(message, COAP_OPTION_OSCORE)){
+          coap_set_oscore(response);
+          if(message->security_context == NULL){
+            LOG_WARN("OSCORE security context is NULL in coap_receive\n");
+          }
           response->security_context = message->security_context;
         }
-        #endif /* WITH_OSCORE */
+#endif /* WITH_OSCORE */
         if(message->token_len) {
           coap_set_token(response, message->token, message->token_len);
           /* get offset for blockwise transfers */
@@ -357,21 +358,20 @@ coap_receive(const coap_endpoint_t *src,
     coap_clear_transaction(transaction);
   } else if(coap_status_code == OSCORE_DECRYPTION_ERROR) {
     LOG_WARN("OSCORE response decryption failed!\n");
-    coap_transaction_t *t = coap_get_transaction_by_mid(message->mid);
-    
-    /* free transaction memory before callback, as it may create a new transaction */
-    coap_resource_response_handler_t callback = t->callback;
-    void *callback_data = t->callback_data;
-    
-    message->code = OSCORE_DECRYPTION_ERROR;
-    coap_clear_transaction(t);
-    printf("TODO send empty ACK!\n");
-    /* check if someone registered for the response */
-    if(callback) {
-      callback(callback_data, message);
+    if ((transaction = coap_get_transaction_by_mid(message->mid))) {
+      /* free transaction memory before callback, as it may create a new transaction */
+      coap_resource_response_handler_t callback = transaction->callback;
+      void *callback_data = transaction->callback_data;
+      
+      message->code = OSCORE_DECRYPTION_ERROR;
+      coap_clear_transaction(transaction);
+      printf("TODO send empty ACK!\n");
+      /* check if someone registered for the response */
+      if(callback) {
+        callback(callback_data, message);
+      }
     }
-    
-    return coap_status_code;
+
   } else {
     coap_message_type_t reply_type = COAP_TYPE_ACK;
 
@@ -390,15 +390,15 @@ coap_receive(const coap_endpoint_t *src,
     uint8_t tmp_token[8];
     uint8_t token_len = 0;
     if(message->token_len) {
-          token_len = message->token_len;
-          memcpy(tmp_token, message->token, token_len);
+      token_len = message->token_len;
+      memcpy(tmp_token, message->token, token_len);
     }
 #endif /* WITH_OSCORE */
     coap_init_message(message, reply_type, coap_status_code,
                       message->mid);
 #ifdef WITH_OSCORE
-    if( token_len){
-        coap_set_token(message, tmp_token, token_len);
+    if(token_len){
+      coap_set_token(message, tmp_token, token_len);
     }
 #endif /* WITH_OSCORE */
     coap_set_payload(message, coap_error_message,

--- a/os/net/app-layer/coap/coap-engine.c
+++ b/os/net/app-layer/coap/coap-engine.c
@@ -143,7 +143,12 @@ call_service(coap_message_t *request, coap_message_t *response,
 extern coap_resource_t res_well_known_core;
 
 #ifdef WITH_OSCORE
-extern void oscore_missing_security_context(const coap_endpoint_t *src);
+static void oscore_missing_security_context_default(const coap_endpoint_t *src)
+{
+}
+
+extern void oscore_missing_security_context(const coap_endpoint_t *src)
+  __attribute__ ((weak, alias ("oscore_missing_security_context_default")));
 #endif
 
 /*---------------------------------------------------------------------------*/

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -426,14 +426,12 @@ coap_serialize_message(coap_message_t *coap_pkt, uint8_t *buffer)
 {
 #ifdef WITH_OSCORE
   if(coap_is_option(coap_pkt, COAP_OPTION_OSCORE)) {
-    //LOG_INFO("Sending OSCORE message: ");
     size_t s = oscore_prepare_message(coap_pkt, buffer);
-    //printf_hex(buffer, s);
-    //LOG_INFO_("\n");
+    LOG_DBG("Sending OSCORE message (size=%zu).\n", s);
     return s;
   } else {
-    LOG_DBG("Sending COAP message.\n");
     size_t s = oscore_serializer(coap_pkt, buffer, ROLE_COAP);
+    LOG_DBG("Sending COAP message (size=%zu).\n", s);
     return s;
   }
 #else /* WITH_OSCORE */

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -426,9 +426,10 @@ coap_serialize_message(coap_message_t *coap_pkt, uint8_t *buffer)
 {
 #ifdef WITH_OSCORE
   if(coap_is_option(coap_pkt, COAP_OPTION_OSCORE)) {
-    LOG_DBG("Sending OSCORE message.\n");
+    //LOG_INFO("Sending OSCORE message: ");
     size_t s = oscore_prepare_message(coap_pkt, buffer);
-    printf_hex(buffer, s);
+    //printf_hex(buffer, s);
+    //LOG_INFO_("\n");
     return s;
   } else {
     LOG_DBG("Sending COAP message.\n");
@@ -488,7 +489,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
   size_t option_length = 0;
   
 #ifdef WITH_OSCORE
-  uint8_t oscore_found = 0;
+  bool oscore_found = false;
 #endif /* WITH_OSCORE */
 
   while(current_option < data + data_len) {
@@ -675,7 +676,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_("Object-Security [");
       LOG_DBG_COAP_STRING((char *)(coap_pkt->object_security), coap_pkt->object_security_len);
       LOG_DBG_("]\n");  
-      oscore_found = 1;
+      oscore_found = true;
       #else /* WITH_OSCORE */
       LOG_DBG_("OSCORE NOT IMPLEMENTED!\n");
       coap_error_message = "OSCORE not supported";
@@ -731,12 +732,12 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
     current_option += option_length;
   }                             /* for */
   LOG_DBG("-Done parsing-------\n");
-  #if WITH_OSCORE
+#if WITH_OSCORE
   if(oscore_found){
    	LOG_DBG_("REMOVE: OSCORE found, decoding\n"); 
 	 return	oscore_decode_message(coap_pkt);
   }
-  #endif /* WITH_OSCORE */
+#endif /* WITH_OSCORE */
   return NO_ERROR;
 }
 /*---------------------------------------------------------------------------*/
@@ -1660,11 +1661,10 @@ int coap_set_header_object_security(coap_message_t *coap_pkt, uint8_t *object_se
 
 
 //TODO for oscore
-int
+void
 coap_set_oscore(coap_message_t *coap_pkt)
 {
   coap_set_option(coap_pkt, COAP_OPTION_OSCORE);
-  return 0;
 }
 #endif /* WITH_OSCORE */
 /** @} */

--- a/os/net/app-layer/coap/coap.c
+++ b/os/net/app-layer/coap/coap.c
@@ -424,20 +424,20 @@ coap_serialize_message_coap(coap_message_t *coap_pkt, uint8_t *buffer)
 size_t
 coap_serialize_message(coap_message_t *coap_pkt, uint8_t *buffer)
 {
-    #ifdef WITH_OSCORE
-    if(coap_is_option(coap_pkt, COAP_OPTION_OSCORE)){
-       LOG_DBG_("Sending OSCORE message.\n");
-       size_t s = oscore_prepare_message(coap_pkt, buffer);
-       printf_hex(buffer, s);
-       return s;
-    }else{
-       LOG_DBG_("Sending COAP message.\n");
-       size_t s = oscore_serializer(coap_pkt, buffer, ROLE_COAP);
-       return s;
-    }
-    #else /* WITH_OSCORE */
-    return coap_serialize_message_coap(coap_pkt, buffer);
-    #endif /* WITH_OSCORE */
+#ifdef WITH_OSCORE
+  if(coap_is_option(coap_pkt, COAP_OPTION_OSCORE)) {
+    LOG_DBG("Sending OSCORE message.\n");
+    size_t s = oscore_prepare_message(coap_pkt, buffer);
+    printf_hex(buffer, s);
+    return s;
+  } else {
+    LOG_DBG("Sending COAP message.\n");
+    size_t s = oscore_serializer(coap_pkt, buffer, ROLE_COAP);
+    return s;
+  }
+#else /* WITH_OSCORE */
+  return coap_serialize_message_coap(coap_pkt, buffer);
+#endif /* WITH_OSCORE */
 }
 
 /*---------------------------------------------------------------------------*/
@@ -669,7 +669,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_("]\n");
       break;
     case COAP_OPTION_OSCORE:
-      #ifdef WITH_OSCORE
+#ifdef WITH_OSCORE
       coap_pkt->object_security = (uint8_t *)current_option;
       coap_pkt->object_security_len = option_length;
       LOG_DBG_("Object-Security [");
@@ -680,7 +680,7 @@ coap_parse_message(coap_message_t *coap_pkt, uint8_t *data, uint16_t data_len)
       LOG_DBG_("OSCORE NOT IMPLEMENTED!\n");
       coap_error_message = "OSCORE not supported";
       return BAD_OPTION_4_02;
-      #endif /* WITH_OSCORE */    
+#endif /* WITH_OSCORE */    
       break;
     case COAP_OPTION_OBSERVE:
       coap_pkt->observe = coap_parse_int_option(current_option,

--- a/os/net/app-layer/coap/coap.h
+++ b/os/net/app-layer/coap/coap.h
@@ -294,7 +294,7 @@ int coap_set_header_location_query(coap_message_t *message, const char *query);
 /* OSCOCRE header functions. */
 int coap_get_header_object_security(coap_message_t *message, uint8_t **object_security);
 int coap_set_header_object_security(coap_message_t *message, uint8_t *object_security, size_t object_security_len);
-int coap_set_oscore(coap_message_t *coap_pkt);
+void coap_set_oscore(coap_message_t *coap_pkt);
 #endif /* WITH_OSCORE */
 int coap_get_header_observe(coap_message_t *message, uint32_t *observe);
 int coap_set_header_observe(coap_message_t *message, uint32_t observe);

--- a/os/net/app-layer/coap/coap.h
+++ b/os/net/app-layer/coap/coap.h
@@ -134,11 +134,11 @@ typedef struct {
   uint16_t payload_len;
   uint8_t *payload;
   
-  #ifdef WITH_OSCORE
+#ifdef WITH_OSCORE
   size_t object_security_len;
   uint8_t *object_security;
   oscore_ctx_t *security_context;
-  #endif /* WITH_OSCORE */
+#endif /* WITH_OSCORE */
 } coap_message_t;
 
 static inline int

--- a/os/net/app-layer/coap/oscore-support/cbor.c
+++ b/os/net/app-layer/coap/oscore-support/cbor.c
@@ -36,20 +36,12 @@
  *
  */
 
-
 #include "cbor.h"
 #include <string.h>
 
-#define DEBUG 0
-#if DEBUG
-#include <stdio.h>
-#define PRINTF(...) printf(__VA_ARGS__)
-#define PRINTF_HEX(data, len)   oscoap_printf_hex(data, len)
-#else
-#define PRINTF(...)
-#define PRINTF_HEX(data, len)
-#endif
-
+#include "coap-log.h"
+#define LOG_MODULE "oscore"
+#define LOG_LEVEL LOG_LEVEL_COAP
 
 int cbor_put_nil(uint8_t **buffer){
 	**buffer = 0xF6;
@@ -83,7 +75,7 @@ cbor_put_array(uint8_t **buffer, uint8_t elements)
 {
   if(elements > 15) {
     /*	#warning "handle this case!\n" */
-    PRINTF("ERROR! in put array\n");
+    LOG_ERR("ERROR! in put array\n");
     return 0;
   }
 
@@ -116,7 +108,7 @@ cbor_put_map(uint8_t **buffer, uint8_t elements)
 {
   if(elements > 15) {
     /*	#warning "handle this case!\n" */
-    PRINTF("ERROR in put map\n");
+    LOG_ERR("ERROR in put map\n");
     return 0;
   }
   **buffer = (0xa0 | elements);

--- a/os/net/app-layer/coap/oscore-support/cbor.c
+++ b/os/net/app-layer/coap/oscore-support/cbor.c
@@ -39,9 +39,13 @@
 #include "cbor.h"
 #include <string.h>
 
-#include "coap-log.h"
+#include "sys/log.h"
 #define LOG_MODULE "oscore"
-#define LOG_LEVEL LOG_LEVEL_COAP
+#ifdef LOG_CONF_LEVEL_OSCORE
+#define LOG_LEVEL LOG_CONF_LEVEL_OSCORE
+#else
+#define LOG_LEVEL LOG_LEVEL_WARN
+#endif
 
 int cbor_put_nil(uint8_t **buffer){
 	**buffer = 0xF6;

--- a/os/net/app-layer/coap/oscore-support/cbor.c
+++ b/os/net/app-layer/coap/oscore-support/cbor.c
@@ -57,7 +57,7 @@ int cbor_put_nil(uint8_t **buffer){
 	return 1;
 }
 int
-cbor_put_text(uint8_t **buffer, char *text, uint8_t text_len)
+cbor_put_text(uint8_t **buffer, const char *text, uint8_t text_len)
 {
   uint8_t ret = 0;
 
@@ -92,7 +92,7 @@ cbor_put_array(uint8_t **buffer, uint8_t elements)
   return 1;
 }
 int
-cbor_put_bytes(uint8_t **buffer, uint8_t *bytes, uint8_t bytes_len)
+cbor_put_bytes(uint8_t **buffer, const uint8_t *bytes, uint8_t bytes_len)
 {
   uint8_t ret = 0;
   if(bytes_len > 23) {

--- a/os/net/app-layer/coap/oscore-support/cbor.h
+++ b/os/net/app-layer/coap/oscore-support/cbor.h
@@ -44,11 +44,11 @@
 
 int cbor_put_nil(uint8_t **buffer);
 
-int cbor_put_text(uint8_t **buffer, char *text, uint8_t text_len);
+int cbor_put_text(uint8_t **buffer, const char *text, uint8_t text_len);
 
 int cbor_put_array(uint8_t **buffer, uint8_t elements);
 
-int cbor_put_bytes(uint8_t **buffer, uint8_t *bytes, uint8_t bytes_len);
+int cbor_put_bytes(uint8_t **buffer, const uint8_t *bytes, uint8_t bytes_len);
 
 int cbor_put_map(uint8_t **buffer, uint8_t elements);
 

--- a/os/net/app-layer/coap/oscore-support/cose.c
+++ b/os/net/app-layer/coap/oscore-support/cose.c
@@ -156,7 +156,11 @@ cose_encrypt0_encrypt(cose_encrypt0_t *ptr)
     return -4;
   }
 
-  return encrypt(ptr->alg, ptr->key, ptr->key_len, ptr->nonce, ptr->nonce_len, ptr->aad, ptr->aad_len, ptr->content, ptr->content_len);
+  return encrypt(ptr->alg,
+    ptr->key, ptr->key_len,
+    ptr->nonce, ptr->nonce_len,
+    ptr->aad, ptr->aad_len,
+    ptr->content, ptr->content_len);
 }
 int
 cose_encrypt0_decrypt(cose_encrypt0_t *ptr)
@@ -174,5 +178,9 @@ cose_encrypt0_decrypt(cose_encrypt0_t *ptr)
     return -4;
   }
 
-  return decrypt(ptr->alg, ptr->key, ptr->key_len, ptr->nonce, ptr->nonce_len, ptr->aad, ptr->aad_len, ptr->content, ptr->content_len);
+  return decrypt(ptr->alg,
+    ptr->key, ptr->key_len,
+    ptr->nonce, ptr->nonce_len,
+    ptr->aad, ptr->aad_len,
+    ptr->content, ptr->content_len);
 }

--- a/os/net/app-layer/coap/oscore-support/cose.c
+++ b/os/net/app-layer/coap/oscore-support/cose.c
@@ -91,14 +91,14 @@ cose_encrypt0_get_partial_iv(cose_encrypt0_t *ptr, uint8_t **buffer)
   return ptr->partial_iv_len;
 }
 void
-cose_encrypt0_set_key_id(cose_encrypt0_t *ptr, uint8_t *buffer, int size)
+cose_encrypt0_set_key_id(cose_encrypt0_t *ptr, const uint8_t *buffer, uint8_t size)
 {
   ptr->key_id = buffer;
   ptr->key_id_len = size;
 }
 /* Return length */
-int
-cose_encrypt0_get_key_id(cose_encrypt0_t *ptr, uint8_t **buffer)
+uint8_t
+cose_encrypt0_get_key_id(cose_encrypt0_t *ptr, const uint8_t **buffer)
 {
   *buffer = ptr->key_id;
   return ptr->key_id_len;

--- a/os/net/app-layer/coap/oscore-support/cose.c
+++ b/os/net/app-layer/coap/oscore-support/cose.c
@@ -153,7 +153,7 @@ cose_encrypt0_encrypt(cose_encrypt0_t *ptr)
     return -3;
   }
   if(ptr->content == NULL ) {
-      return -4;
+    return -4;
   }
 
   return encrypt(ptr->alg, ptr->key, ptr->key_len, ptr->nonce, ptr->nonce_len, ptr->aad, ptr->aad_len, ptr->content, ptr->content_len);

--- a/os/net/app-layer/coap/oscore-support/cose.h
+++ b/os/net/app-layer/coap/oscore-support/cose.h
@@ -65,8 +65,8 @@ typedef struct cose_encrypt0_t {
   uint8_t partial_iv[8];
   int partial_iv_len;
 
-  uint8_t *key_id;
-  int key_id_len;
+  const uint8_t *key_id;
+  uint8_t key_id_len;
 
   uint8_t *kid_context;
   int kid_context_len;
@@ -104,8 +104,8 @@ void cose_encrypt0_set_partial_iv(cose_encrypt0_t *ptr, uint8_t *buffer, int siz
 
 
 /* Return length */
-int cose_encrypt0_get_key_id(cose_encrypt0_t *ptr, uint8_t **buffer);
-void cose_encrypt0_set_key_id(cose_encrypt0_t *ptr, uint8_t *buffer, int size);
+uint8_t cose_encrypt0_get_key_id(cose_encrypt0_t *ptr, const uint8_t **buffer);
+void cose_encrypt0_set_key_id(cose_encrypt0_t *ptr, const uint8_t *buffer, uint8_t size);
 
 void cose_encrypt0_set_aad(cose_encrypt0_t *ptr, uint8_t *buffer, int size);
 

--- a/os/net/app-layer/coap/oscore-support/oscore-context.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.c
@@ -50,9 +50,13 @@
 #include <stdio.h>
 
 /* Log configuration */
-#include "coap-log.h"
+#include "sys/log.h"
 #define LOG_MODULE "oscore"
-#define LOG_LEVEL LOG_LEVEL_COAP
+#ifdef LOG_CONF_LEVEL_OSCORE
+#define LOG_LEVEL LOG_CONF_LEVEL_OSCORE
+#else
+#define LOG_LEVEL LOG_LEVEL_WARN
+#endif
 
 MEMB(exchange_memb, oscore_exchange_t, TOKEN_SEQ_NUM);
 MEMB(ep_ctx_memb, ep_ctx_t, EP_CTX_NUM);

--- a/os/net/app-layer/coap/oscore-support/oscore-context.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.c
@@ -45,8 +45,14 @@
 #include <string.h>
 #include "oscore-crypto.h"
 #include "oscore.h"
+#include "assert.h"
 
 #include <stdio.h>
+
+/* Log configuration */
+#include "coap-log.h"
+#define LOG_MODULE "oscore"
+#define LOG_LEVEL LOG_LEVEL_COAP
 
 MEMB(exchange_memb, oscore_exchange_t, TOKEN_SEQ_NUM);
 MEMB(ep_ctx_memb, ep_ctx_t, EP_CTX_NUM);
@@ -239,24 +245,28 @@ oscore_ep_ctx_store_init(void)
   memb_init(&ep_ctx_memb);
   list_init(ep_ctx_list);
 }
-uint8_t
+bool
 oscore_ep_ctx_set_association(coap_endpoint_t *ep, const char *uri, oscore_ctx_t *ctx)
 {
-  if( list_length(ep_ctx_list) == EP_CTX_NUM){ /* If we are at capacity for Endpoint <-> Context associations: */
+#if 0
+  if(list_length(ep_ctx_list) == EP_CTX_NUM){ /* If we are at capacity for Endpoint <-> Context associations: */
 	/* Remove first element in list, to make space for a new one. */
         ep_ctx_t *tmp = list_pop(ep_ctx_list);
 	memb_free(&ep_ctx_memb, tmp);
   }
+#endif
+
   ep_ctx_t *new_ep_ctx = memb_alloc(&ep_ctx_memb);
   if(new_ep_ctx == NULL) {
-    return 0;
+    LOG_ERR("oscore_ep_ctx_set_association: out of memory\n");
+    return false;
   }
   new_ep_ctx->ep = ep;
   new_ep_ctx->uri = uri;
   new_ep_ctx->ctx = ctx;
   list_add(ep_ctx_list, new_ep_ctx);
  
-  return 1;
+  return true;
 }
 
 int _strcmp(const char *a, const char *b){

--- a/os/net/app-layer/coap/oscore-support/oscore-context.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.c
@@ -240,7 +240,7 @@ oscore_ep_ctx_store_init(void)
   list_init(ep_ctx_list);
 }
 uint8_t
-oscore_ep_ctx_set_association(coap_endpoint_t *ep, char *uri, oscore_ctx_t *ctx)
+oscore_ep_ctx_set_association(coap_endpoint_t *ep, const char *uri, oscore_ctx_t *ctx)
 {
   if( list_length(ep_ctx_list) == EP_CTX_NUM){ /* If we are at capacity for Endpoint <-> Context associations: */
 	/* Remove first element in list, to make space for a new one. */

--- a/os/net/app-layer/coap/oscore-support/oscore-context.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.h
@@ -51,16 +51,12 @@
 
 #define OSCORE_SEQ_MAX (((uint64_t)1 << 40) - 1)
 
-#ifndef CONTEXT_NUM
-#define CONTEXT_NUM 2
-#endif
-
 #ifndef TOKEN_SEQ_NUM
-#define TOKEN_SEQ_NUM 2
+#define TOKEN_SEQ_NUM 10
 #endif
 
 #ifndef EP_CTX_NUM
-#define EP_CTX_NUM 2
+#define EP_CTX_NUM 10
 #endif
 
 typedef struct oscore_sender_ctx_t oscore_sender_ctx_t;
@@ -138,9 +134,9 @@ oscore_ctx_t *oscore_find_ctx_by_rid(const uint8_t *rid, uint8_t rid_len);
 
 /* Token <=> SEQ association */
 void oscore_exchange_store_init(void);
-uint8_t oscore_set_exchange(uint8_t *token, uint8_t token_len, uint64_t seq, oscore_ctx_t *context);
-oscore_ctx_t* oscore_get_exchange(uint8_t *token, uint8_t token_len, uint64_t *seq);
-void oscore_remove_exchange(uint8_t *token, uint8_t token_len);
+bool oscore_set_exchange(const uint8_t *token, uint8_t token_len, uint64_t seq, oscore_ctx_t *context);
+oscore_ctx_t* oscore_get_contex_from_exchange(const uint8_t *token, uint8_t token_len, uint64_t *seq);
+void oscore_remove_exchange(const uint8_t *token, uint8_t token_len);
 
 /* URI <=> CTX association */
 void oscore_ep_ctx_store_init(void);

--- a/os/net/app-layer/coap/oscore-support/oscore-context.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.h
@@ -98,8 +98,8 @@ struct oscore_ctx_t {
   uint8_t *master_salt;
   uint8_t common_iv[CONTEXT_INIT_VECT_LEN];
   uint8_t *id_context;
-  oscore_sender_ctx_t *sender_context;
-  oscore_recipient_ctx_t *recipient_context;
+  oscore_sender_ctx_t sender_context;
+  oscore_recipient_ctx_t recipient_context;
   uint8_t master_secret_len;
   uint8_t master_salt_len;
   uint8_t id_context_len;
@@ -123,20 +123,27 @@ struct ep_ctx_t {
 void oscore_ctx_store_init();
 
 //replay window default is 32
-oscore_ctx_t *oscore_derive_ctx(uint8_t *master_secret, uint8_t master_secret_len, uint8_t *master_salt, uint8_t master_salt_len, uint8_t alg, uint8_t *sid, uint8_t sid_len, uint8_t *rid, uint8_t rid_len, uint8_t *id_context, uint8_t id_context_len, uint8_t replay_window);
+void oscore_derive_ctx(oscore_ctx_t *common_ctx,
+  uint8_t *master_secret, uint8_t master_secret_len,
+  uint8_t *master_salt, uint8_t master_salt_len,
+  uint8_t alg,
+  uint8_t *sid, uint8_t sid_len,
+  uint8_t *rid, uint8_t rid_len,
+  uint8_t *id_context, uint8_t id_context_len,
+  uint8_t replay_window);
 
-int oscore_free_ctx(oscore_ctx_t *ctx);
+void oscore_free_ctx(oscore_ctx_t *ctx);
 
 oscore_ctx_t *oscore_find_ctx_by_rid(uint8_t *rid, uint8_t rid_len);
 
 /* Token <=> SEQ association */
-void oscore_exchange_store_init();
+void oscore_exchange_store_init(void);
 uint8_t oscore_set_exchange(uint8_t *token, uint8_t token_len, uint64_t seq, oscore_ctx_t *context);
 oscore_ctx_t* oscore_get_exchange(uint8_t *token, uint8_t token_len, uint64_t *seq);
 void oscore_remove_exchange(uint8_t *token, uint8_t token_len);
 
 /* URI <=> CTX association */
-void oscore_ep_ctx_store_init();
+void oscore_ep_ctx_store_init(void);
 uint8_t oscore_ep_ctx_set_association(coap_endpoint_t *ep, char *uri, oscore_ctx_t *ctx);
 oscore_ctx_t *oscore_get_context_from_ep(coap_endpoint_t *ep, const char *uri);
 void oscore_remove_ep_ctx(coap_endpoint_t *ep, const char *uri);

--- a/os/net/app-layer/coap/oscore-support/oscore-context.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.h
@@ -144,7 +144,7 @@ void oscore_remove_exchange(uint8_t *token, uint8_t token_len);
 
 /* URI <=> CTX association */
 void oscore_ep_ctx_store_init(void);
-uint8_t oscore_ep_ctx_set_association(coap_endpoint_t *ep, const char *uri, oscore_ctx_t *ctx);
+bool oscore_ep_ctx_set_association(coap_endpoint_t *ep, const char *uri, oscore_ctx_t *ctx);
 oscore_ctx_t *oscore_get_context_from_ep(coap_endpoint_t *ep, const char *uri);
 void oscore_remove_ep_ctx(coap_endpoint_t *ep, const char *uri);
 #endif /* _OSCORE_CONTEXT_H */

--- a/os/net/app-layer/coap/oscore-support/oscore-context.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.h
@@ -73,7 +73,7 @@ struct oscore_sender_ctx_t {
   uint8_t sender_key[CONTEXT_KEY_LEN];
   uint8_t token[COAP_TOKEN_LEN];
   uint64_t seq;
-  uint8_t *sender_id;
+  const uint8_t *sender_id;
   uint8_t sender_id_len;
   uint8_t token_len;
 };
@@ -84,9 +84,9 @@ struct oscore_recipient_ctx_t {
   uint64_t recent_seq;
   uint32_t sliding_window;
   int32_t rollback_sliding_window;
-  oscore_recipient_ctx_t *recipient_context; /* This field facilitates easy integration of OSCOAP multicast */
+  //oscore_recipient_ctx_t *recipient_context; /* This field facilitates easy integration of OSCOAP multicast */
   uint8_t recipient_key[CONTEXT_KEY_LEN];
-  uint8_t *recipient_id;
+  const uint8_t *recipient_id;
   uint8_t recipient_id_len;
   uint8_t replay_window_size;
   uint8_t initialized;
@@ -94,10 +94,10 @@ struct oscore_recipient_ctx_t {
 
 struct oscore_ctx_t {
   oscore_ctx_t *next;
-  uint8_t *master_secret;
-  uint8_t *master_salt;
+  const uint8_t *master_secret;
+  const uint8_t *master_salt;
   uint8_t common_iv[CONTEXT_INIT_VECT_LEN];
-  uint8_t *id_context;
+  const uint8_t *id_context;
   oscore_sender_ctx_t sender_context;
   oscore_recipient_ctx_t recipient_context;
   uint8_t master_secret_len;
@@ -124,17 +124,17 @@ void oscore_ctx_store_init();
 
 //replay window default is 32
 void oscore_derive_ctx(oscore_ctx_t *common_ctx,
-  uint8_t *master_secret, uint8_t master_secret_len,
-  uint8_t *master_salt, uint8_t master_salt_len,
+  const uint8_t *master_secret, uint8_t master_secret_len,
+  const uint8_t *master_salt, uint8_t master_salt_len,
   uint8_t alg,
-  uint8_t *sid, uint8_t sid_len,
-  uint8_t *rid, uint8_t rid_len,
-  uint8_t *id_context, uint8_t id_context_len,
+  const uint8_t *sid, uint8_t sid_len,
+  const uint8_t *rid, uint8_t rid_len,
+  const uint8_t *id_context, uint8_t id_context_len,
   uint8_t replay_window);
 
 void oscore_free_ctx(oscore_ctx_t *ctx);
 
-oscore_ctx_t *oscore_find_ctx_by_rid(uint8_t *rid, uint8_t rid_len);
+oscore_ctx_t *oscore_find_ctx_by_rid(const uint8_t *rid, uint8_t rid_len);
 
 /* Token <=> SEQ association */
 void oscore_exchange_store_init(void);

--- a/os/net/app-layer/coap/oscore-support/oscore-context.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-context.h
@@ -117,7 +117,7 @@ struct oscore_exchange_t {
 struct ep_ctx_t {
   ep_ctx_t *next;
   coap_endpoint_t *ep;
-  char *uri;
+  const char *uri;
   oscore_ctx_t *ctx;
 };
 void oscore_ctx_store_init();
@@ -144,7 +144,7 @@ void oscore_remove_exchange(uint8_t *token, uint8_t token_len);
 
 /* URI <=> CTX association */
 void oscore_ep_ctx_store_init(void);
-uint8_t oscore_ep_ctx_set_association(coap_endpoint_t *ep, char *uri, oscore_ctx_t *ctx);
+uint8_t oscore_ep_ctx_set_association(coap_endpoint_t *ep, const char *uri, oscore_ctx_t *ctx);
 oscore_ctx_t *oscore_get_context_from_ep(coap_endpoint_t *ep, const char *uri);
 void oscore_remove_ep_ctx(coap_endpoint_t *ep, const char *uri);
 #endif /* _OSCORE_CONTEXT_H */

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.c
@@ -102,16 +102,18 @@ encrypt(uint8_t alg,
   kprintf_hex(aad, aad_len);
   printf("Plaintext: (%" PRIu16 ")\n", plaintext_len);
   kprintf_hex(buffer, plaintext_len);
+  printf("Tag: (%" PRIu8 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  kprintf_hex(tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
 #endif
 
   CCM_STAR.set_key(key);
   CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 1);
 
 #ifdef OSCORE_ENC_DEC_DEBUG
+  printf("Tag': (%" PRIu8 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  kprintf_hex(tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
   printf("Ciphertext: (%" PRIu16 ")\n", plaintext_len);
   kprintf_hex(buffer, plaintext_len);
-  printf("Tag: (%" PRIu16 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
-  kprintf_hex(tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
 #endif
 
   return plaintext_len + COSE_algorithm_AES_CCM_16_64_128_TAG_LEN;
@@ -144,8 +146,6 @@ decrypt(uint8_t alg,
 
   uint8_t tag_buffer[COSE_algorithm_AES_CCM_16_64_128_TAG_LEN];
   
-  CCM_STAR.set_key(key);
-
   uint16_t plaintext_len = ciphertext_len - COSE_algorithm_AES_CCM_16_64_128_TAG_LEN;
 
 #ifdef OSCORE_ENC_DEC_DEBUG
@@ -158,10 +158,11 @@ decrypt(uint8_t alg,
   kprintf_hex(aad, aad_len);
   printf("Ciphertext: (%" PRIu16 ")\n", plaintext_len);
   kprintf_hex(buffer, plaintext_len);
-  printf("Tag: (%" PRIu16 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  printf("Tag: (%" PRIu8 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
   kprintf_hex(&buffer[plaintext_len], COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
 #endif
 
+  CCM_STAR.set_key(key);
   CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 0);
 
 #ifdef OSCORE_ENC_DEC_DEBUG

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.c
@@ -36,8 +36,6 @@
  *
  */
 
-
-
 #include "oscore-crypto.h"
 #include "ccm-star.h"
 #include <string.h>
@@ -53,98 +51,133 @@
 #define LOG_MODULE "oscore"
 #define LOG_LEVEL LOG_LEVEL_COAP
 
-/*static void
-kprintf_hex(const unsigned char *data, unsigned int len)
+//#define OSCORE_ENC_DEC_DEBUG
+
+#ifdef OSCORE_ENC_DEC_DEBUG
+static void
+kprintf_hex(const uint8_t *data, unsigned int len)
 {
   unsigned int i = 0;
   for(i = 0; i < len; i++) {
-    printf("%02x ", data[i]);
+    printf("%02x", data[i]);
   }
   printf("\n");
-}*/
+}
+#endif
+
 /* Returns 0 if failure to encrypt. Ciphertext length, otherwise.
    Tag-length and ciphertext length is derived from algorithm. No check is done to ensure
    that ciphertext buffer is of the correct length. */
 int
-encrypt(uint8_t alg, uint8_t *key, uint8_t key_len, uint8_t *nonce, uint8_t nonce_len,
-        uint8_t *aad, uint8_t aad_len, uint8_t *buffer, uint16_t plaintext_len)
+encrypt(uint8_t alg,
+        const uint8_t *key, uint8_t key_len,
+        const uint8_t *nonce, uint8_t nonce_len,
+        const uint8_t *aad, uint8_t aad_len,
+        uint8_t *buffer, uint16_t plaintext_len)
 {
   if(alg != COSE_Algorithm_AES_CCM_16_64_128) {
     LOG_ERR("Unsupported algorithm %u\n", alg);
-    return -5;
+    return OSCORE_CRYPTO_UNSUPPORTED_ALGORITHM;
   }
 
   if(key_len != COSE_algorithm_AES_CCM_16_64_128_KEY_LEN) {
     LOG_ERR("Invalid key length %u != %u\n", key_len, COSE_algorithm_AES_CCM_16_64_128_KEY_LEN);
-    return -5;
+    return OSCORE_CRYPTO_INVALID_KEY_LEN;
   }
 
   if(nonce_len != COSE_algorithm_AES_CCM_16_64_128_IV_LEN) {
     LOG_ERR("Invalid nonce length %u != %u\n", nonce_len, COSE_algorithm_AES_CCM_16_64_128_IV_LEN);
-    return -5;
+    return OSCORE_CRYPTO_INVALID_NONCE_LEN;
   }
 
+  uint8_t* tag_buffer = &buffer[plaintext_len];
+
+#ifdef OSCORE_ENC_DEC_DEBUG
+  printf("Encrypt:\n");
+  printf("Key: (%" PRIu8 ")\n", key_len);
+  kprintf_hex(key, key_len);
+  printf("IV: (%" PRIu8 ")\n", nonce_len);
+  kprintf_hex(nonce, nonce_len);
+  printf("AAD: (%" PRIu8 ")\n", aad_len);
+  kprintf_hex(aad, aad_len);
+  printf("Plaintext: (%" PRIu16 ")\n", plaintext_len);
+  kprintf_hex(buffer, plaintext_len);
+#endif
+
   CCM_STAR.set_key(key);
-  CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, &(buffer[plaintext_len]), COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 1);
-/*
-   printf("Encrypt:\n");
-   printf("Key:\n");
-   kprintf_hex(key, key_len);
-   printf("IV:\n");
-   kprintf_hex(nonce, nonce_len);
-   printf("AAD:\n");
-   kprintf_hex(aad, aad_len);
-   printf("Plaintext:\n");
-   kprintf_hex(plaintext_buffer, plaintext_len);
-   printf("Ciphertext&Tag:\n");
-   kprintf_hex(encryption_buffer, plaintext_len + 8);
- */
+  CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 1);
+
+#ifdef OSCORE_ENC_DEC_DEBUG
+  printf("Ciphertext: (%" PRIu16 ")\n", plaintext_len);
+  kprintf_hex(buffer, plaintext_len);
+  printf("Tag: (%" PRIu16 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  kprintf_hex(tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+#endif
+
   return plaintext_len + COSE_algorithm_AES_CCM_16_64_128_TAG_LEN;
 }
+
 /* Return 0 if if decryption failure. Plaintext length otherwise.
    Tag-length and plaintext length is derived from algorithm. No check is done to ensure
    that plaintext buffer is of the correct length. */
 int
-decrypt(uint8_t alg, uint8_t *key, uint8_t key_len, uint8_t *nonce, uint8_t nonce_len,
-        uint8_t *aad, uint8_t aad_len, uint8_t *buffer, uint16_t ciphertext_len)
+decrypt(uint8_t alg,
+        const uint8_t *key, uint8_t key_len,
+        const uint8_t *nonce, uint8_t nonce_len,
+        const uint8_t *aad, uint8_t aad_len,
+        uint8_t *buffer, uint16_t ciphertext_len)
 {
   if(alg != COSE_Algorithm_AES_CCM_16_64_128) {
     LOG_ERR("Unsupported algorithm %u\n", alg);
-    return -5;
+    return OSCORE_CRYPTO_UNSUPPORTED_ALGORITHM;
   }
 
   if(key_len != COSE_algorithm_AES_CCM_16_64_128_KEY_LEN) {
     LOG_ERR("Invalid key length %u != %u\n", key_len, COSE_algorithm_AES_CCM_16_64_128_KEY_LEN);
-    return -5;
+    return OSCORE_CRYPTO_INVALID_KEY_LEN;
   }
 
   if(nonce_len != COSE_algorithm_AES_CCM_16_64_128_IV_LEN) {
     LOG_ERR("Invalid nonce length %u != %u\n", nonce_len, COSE_algorithm_AES_CCM_16_64_128_IV_LEN);
-    return -5;
+    return OSCORE_CRYPTO_INVALID_NONCE_LEN;
   }
 
   uint8_t tag_buffer[COSE_algorithm_AES_CCM_16_64_128_TAG_LEN];
   
   CCM_STAR.set_key(key);
-/*    printf("Decrypt:\n");
-     printf("Key:\n");
-     kprintf_hex(key, key_len);
-     printf("IV:\n");
-     kprintf_hex(nonce, nonce_len);
-     printf("AAD:\n");
-     kprintf_hex(aad, aad_len);
-     printf("Ciphertext&Tag:\n");
-     kprintf_hex(decryption_buffer, ciphertext_len);
- */
+
   uint16_t plaintext_len = ciphertext_len - COSE_algorithm_AES_CCM_16_64_128_TAG_LEN;
+
+#ifdef OSCORE_ENC_DEC_DEBUG
+  printf("Decrypt:\n");
+  printf("Key: (%" PRIu8 ")\n", key_len);
+  kprintf_hex(key, key_len);
+  printf("IV: (%" PRIu8 ")\n", nonce_len);
+  kprintf_hex(nonce, nonce_len);
+  printf("AAD: (%" PRIu8 ")\n", aad_len);
+  kprintf_hex(aad, aad_len);
+  printf("Ciphertext: (%" PRIu16 ")\n", plaintext_len);
+  kprintf_hex(buffer, plaintext_len);
+  printf("Tag: (%" PRIu16 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  kprintf_hex(&buffer[plaintext_len], COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+#endif
+
   CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 0);
 
-  if(memcmp(tag_buffer, &(buffer[plaintext_len]), COSE_algorithm_AES_CCM_16_64_128_TAG_LEN) != 0) {
-    return 0; /* Decryption failure */
+#ifdef OSCORE_ENC_DEC_DEBUG
+  printf("Tag': (%" PRIu8 ")\n", COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  kprintf_hex(tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN);
+  printf("Plaintext: (%" PRIu16 ")\n", plaintext_len);
+  kprintf_hex(buffer, plaintext_len);
+#endif
+
+  if(memcmp(tag_buffer, &buffer[plaintext_len], COSE_algorithm_AES_CCM_16_64_128_TAG_LEN) != 0) {
+    return OSCORE_CRYPTO_DECRYPTION_FAILURE; /* Decryption/Authentication failure */
   }
   
   return plaintext_len;
 }
+
 /* only works with key_len <= 64 bytes */
 void
 hmac_sha256(const uint8_t *key, uint8_t key_len, const uint8_t *data, uint8_t data_len, uint8_t *hmac)
@@ -170,14 +203,15 @@ hkdf_extract(const uint8_t *salt, uint8_t salt_len, const uint8_t *ikm, uint8_t 
   
   hmac_sha256(salt, salt_len, ikm, ikm_len, prk_buffer);
 }
+
 static int
 hkdf_expand(const uint8_t *prk, const uint8_t *info, uint8_t info_len, uint8_t *okm, uint8_t okm_len)
 {
   if(info_len > HKDF_INFO_MAXLEN) {
-    return -1;
+    return OSCORE_CRYPTO_HKDF_INVALID_INFO_LEN;
   }
   if(okm_len > HKDF_OUTPUT_MAXLEN) {
-    return -2;
+    return OSCORE_CRYPTO_HKDF_INVALID_OKM_LEN;
   }
   int N = (okm_len + 32 - 1) / 32; /* ceil(okm_len/32) */
   uint8_t aggregate_buffer[32 + HKDF_INFO_MAXLEN + 1];
@@ -198,6 +232,7 @@ hkdf_expand(const uint8_t *prk, const uint8_t *info, uint8_t info_len, uint8_t *
   }
 
   memcpy(okm, out_buffer, okm_len);
+
   return 0;
 }
 
@@ -210,6 +245,5 @@ hkdf(
 {
   uint8_t prk_buffer[32];
   hkdf_extract(salt, salt_len, ikm, ikm_len, prk_buffer);
-  hkdf_expand(prk_buffer, info, info_len, okm, okm_len);
-  return 0;
+  return hkdf_expand(prk_buffer, info, info_len, okm, okm_len);
 }

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.c
@@ -140,7 +140,7 @@ decrypt(uint8_t alg, uint8_t *key, uint8_t key_len, uint8_t *nonce, uint8_t nonc
   CCM_STAR.aead(nonce, buffer, plaintext_len, aad, aad_len, tag_buffer, COSE_algorithm_AES_CCM_16_64_128_TAG_LEN, 0);
 
   if(memcmp(tag_buffer, &(buffer[plaintext_len]), COSE_algorithm_AES_CCM_16_64_128_TAG_LEN) != 0) {
-          return 0; /* Decryption failure */
+    return 0; /* Decryption failure */
   }
   
   return plaintext_len;

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.c
@@ -194,7 +194,7 @@ hmac_sha256(const uint8_t *key, uint8_t key_len, const uint8_t *data, uint8_t da
 static void
 hkdf_extract(const uint8_t *salt, uint8_t salt_len, const uint8_t *ikm, uint8_t ikm_len, uint8_t *prk_buffer)
 {
-  uint8_t zeroes[32];
+  uint8_t zeroes[DTLS_SHA256_DIGEST_LENGTH];
   memset(zeroes, 0, sizeof(zeroes));
 
   if(salt == NULL || salt_len == 0){
@@ -244,7 +244,7 @@ hkdf(
   uint8_t *info, uint8_t info_len,
   uint8_t *okm, uint8_t okm_len)
 {
-  uint8_t prk_buffer[32];
+  uint8_t prk_buffer[DTLS_SHA256_DIGEST_LENGTH];
   hkdf_extract(salt, salt_len, ikm, ikm_len, prk_buffer);
   return hkdf_expand(prk_buffer, info, info_len, okm, okm_len);
 }

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.h
@@ -56,12 +56,26 @@
 #define AEAD_TAG_MAXLEN 16  
 
 /* Returns 0 if failure to encrypt. Ciphertext length, otherwise. Tag-length and ciphertext length is derived from algorithm. No check is done to ensure that ciphertext buffer is of the correct length. */
-int encrypt(uint8_t alg, uint8_t *key, uint8_t key_len, uint8_t *nonce, uint8_t nonce_len, uint8_t *aad, uint8_t aad_len, uint8_t *buffer, uint16_t plaintext_len);
+int encrypt(
+	uint8_t alg,
+	uint8_t *key, uint8_t key_len,
+	uint8_t *nonce, uint8_t nonce_len,
+	uint8_t *aad, uint8_t aad_len,
+	uint8_t *buffer, uint16_t plaintext_len);
 
 /* Return 0 if if decryption failure. Plaintext length otherwise. Tag-length and plaintext length is derived from algorithm. No check is done to ensure that plaintext buffer is of the correct length. */
-int decrypt(uint8_t alg, uint8_t *key, uint8_t key_len, uint8_t *nonce, uint8_t nonce_len, uint8_t *aad, uint8_t aad_len, uint8_t *buffer, uint16_t ciphertext_len);
+int decrypt(
+	uint8_t alg,
+	uint8_t *key, uint8_t key_len,
+	uint8_t *nonce, uint8_t nonce_len,
+	uint8_t *aad, uint8_t aad_len,
+	uint8_t *buffer, uint16_t ciphertext_len);
 
 /* int hkdf(uint8_t whichSha, const uint8_t *salt, uint8_t salt_len, const uint8_t *ikm,  uint8_t ikm_len, const uint8_t *info, uint8_t info_len, uint8_t *okm, uint8_t   okm_len); */
-int hkdf(const uint8_t *salt, uint8_t salt_len, const uint8_t *ikm, uint8_t ikm_len, uint8_t *info, uint8_t info_len, uint8_t *okm, uint8_t okm_len);
+int hkdf(
+	const uint8_t *salt, uint8_t salt_len,
+	const uint8_t *ikm, uint8_t ikm_len,
+	uint8_t *info, uint8_t info_len,
+	uint8_t *okm, uint8_t okm_len);
 
 #endif /* _CRYPTO_H */

--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.h
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.h
@@ -53,22 +53,29 @@
 /* Plaintext Maxlen and Tag Maxlen is quite generous. */
 #define AEAD_PLAINTEXT_MAXLEN COAP_MAX_CHUNK_SIZE
 /* Enough for all COSE-AES-CCM algorithms. */
-#define AEAD_TAG_MAXLEN 16  
+#define AEAD_TAG_MAXLEN 16
+
+#define OSCORE_CRYPTO_DECRYPTION_FAILURE     0
+#define OSCORE_CRYPTO_HKDF_INVALID_INFO_LEN -1
+#define OSCORE_CRYPTO_HKDF_INVALID_OKM_LEN  -2
+#define OSCORE_CRYPTO_UNSUPPORTED_ALGORITHM -5
+#define OSCORE_CRYPTO_INVALID_KEY_LEN       -6
+#define OSCORE_CRYPTO_INVALID_NONCE_LEN     -7
 
 /* Returns 0 if failure to encrypt. Ciphertext length, otherwise. Tag-length and ciphertext length is derived from algorithm. No check is done to ensure that ciphertext buffer is of the correct length. */
 int encrypt(
 	uint8_t alg,
-	uint8_t *key, uint8_t key_len,
-	uint8_t *nonce, uint8_t nonce_len,
-	uint8_t *aad, uint8_t aad_len,
+	const uint8_t *key, uint8_t key_len,
+	const uint8_t *nonce, uint8_t nonce_len,
+	const uint8_t *aad, uint8_t aad_len,
 	uint8_t *buffer, uint16_t plaintext_len);
 
 /* Return 0 if if decryption failure. Plaintext length otherwise. Tag-length and plaintext length is derived from algorithm. No check is done to ensure that plaintext buffer is of the correct length. */
 int decrypt(
 	uint8_t alg,
-	uint8_t *key, uint8_t key_len,
-	uint8_t *nonce, uint8_t nonce_len,
-	uint8_t *aad, uint8_t aad_len,
+	const uint8_t *key, uint8_t key_len,
+	const uint8_t *nonce, uint8_t nonce_len,
+	const uint8_t *aad, uint8_t aad_len,
 	uint8_t *buffer, uint16_t ciphertext_len);
 
 /* int hkdf(uint8_t whichSha, const uint8_t *salt, uint8_t salt_len, const uint8_t *ikm,  uint8_t ikm_len, const uint8_t *info, uint8_t info_len, uint8_t *okm, uint8_t   okm_len); */

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -248,8 +248,8 @@ oscore_decode_message(coap_message_t *coap_pkt)
   cose_encrypt0_set_aad(cose, aad_buffer, aad_len);
   cose_encrypt0_set_alg(cose, ctx->alg);
   
-  oscore_generate_nonce(cose, coap_pkt, nonce_buffer, 13);
-  cose_encrypt0_set_nonce(cose, nonce_buffer, 13);
+  oscore_generate_nonce(cose, coap_pkt, nonce_buffer, sizeof(nonce_buffer));
+  cose_encrypt0_set_nonce(cose, nonce_buffer, sizeof(nonce_buffer));
   
   cose_encrypt0_set_content(cose, coap_pkt->payload, coap_pkt->payload_len);
   int res = cose_encrypt0_decrypt(cose);

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -58,12 +58,21 @@
 /* Sets Alg, Partial IV Key ID and Key in COSE. */
 static void oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, bool sending, uint8_t partial_iv_buffer[8]);
 
-void
+static void
 printf_hex(const uint8_t *data, size_t len)
 {
   for(size_t i = 0; i < len; i++) {
     LOG_ERR_("%02x", data[i]);
   }
+}
+static void
+printf_hex_detailed(const char* name, const uint8_t *data, size_t len)
+{
+  LOG_DBG("%s (len=%u): ", name, len);
+  for(size_t i = 0; i < len; i++) {
+    LOG_DBG_("%02x", data[i]);
+  }
+  LOG_DBG_("\n");
 }
 
 static bool
@@ -126,8 +135,8 @@ btou64(uint8_t *bytes, size_t len)
 
   return num;
 }
-int
-oscore_encode_option_value(uint8_t *option_buffer, cose_encrypt0_t *cose, uint8_t include_partial_iv)
+static int
+oscore_encode_option_value(uint8_t *option_buffer, cose_encrypt0_t *cose, bool include_partial_iv)
 {
   uint8_t offset = 1;
   if(cose->partial_iv_len > 5){
@@ -209,6 +218,8 @@ oscore_decode_message(coap_message_t *coap_pkt)
   uint8_t seq_buffer[8];
   uint8_t partial_iv_buffer[8];
   cose_encrypt0_init(cose);
+
+  printf_hex_detailed("object_security", coap_pkt->object_security, coap_pkt->object_security_len);
 
   /* Options are discarded later when they are overwritten. This should be improved */
   coap_status_t ret = oscore_decode_option_value(coap_pkt->object_security, coap_pkt->object_security_len, cose);
@@ -360,12 +371,9 @@ oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer)
     return PACKET_SERIALIZATION_ERROR;
   }
   
-  uint8_t option_value_len = 0;
-  if(coap_is_request(coap_pkt)) {
-    option_value_len = oscore_encode_option_value(option_value_buffer, cose, 1);
-  } else { //Partial IV shall NOT be included in responses
-    option_value_len = oscore_encode_option_value(option_value_buffer, cose, 0);
-  }
+  // Partial IV shall NOT be included in responses if not a request
+  const bool include_partial_iv = coap_is_request(coap_pkt);
+  uint8_t option_value_len = oscore_encode_option_value(option_value_buffer, cose, include_partial_iv);
   
   coap_set_payload(coap_pkt, content_buffer, ciphertext_len);
   coap_set_header_object_security(coap_pkt, option_value_buffer, option_value_len);
@@ -426,6 +434,10 @@ oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buf
 void
 oscore_generate_nonce(cose_encrypt0_t *ptr, coap_message_t *coap_pkt, uint8_t *buffer, uint8_t size)
 {
+  printf_hex_detailed("key_id", ptr->key_id, ptr->key_id_len);
+  printf_hex_detailed("partial_iv", ptr->partial_iv, ptr->partial_iv_len);
+  printf_hex_detailed("common_iv", coap_pkt->security_context->common_iv, CONTEXT_INIT_VECT_LEN);
+
   memset(buffer, 0, size);
   buffer[0] = (uint8_t)(ptr->key_id_len);
   memcpy(&(buffer[((size - 5) - ptr->key_id_len)]), ptr->key_id, ptr->key_id_len);
@@ -434,6 +446,8 @@ oscore_generate_nonce(cose_encrypt0_t *ptr, coap_message_t *coap_pkt, uint8_t *b
   for(i = 0; i < size; i++) {
     buffer[i] ^= (uint8_t)coap_pkt->security_context->common_iv[i];
   }
+
+  printf_hex_detailed("result", buffer, size);
 }
 /*Remove all protected options */
 void
@@ -463,8 +477,9 @@ bool
 oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose)
 {
   int64_t incomming_seq = btou64(cose->partial_iv, cose->partial_iv_len);
-//todo add LOG_DBG here 
+
   LOG_DBG("Incomming SEQ %" PRIi64 "\n", incomming_seq);
+
   ctx->rollback_largest_seq = ctx->largest_seq;
   ctx->rollback_sliding_window = ctx->sliding_window;
 
@@ -516,6 +531,8 @@ oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose)
 bool
 oscore_increment_sender_seq(oscore_ctx_t *ctx)
 {
+  LOG_DBG("Incrementing seq to %"PRIu64"\n", ctx->sender_context.seq + 1);
+
   ctx->sender_context.seq++;
   return ctx->sender_context.seq < OSCORE_SEQ_MAX;
 }
@@ -523,6 +540,10 @@ oscore_increment_sender_seq(oscore_ctx_t *ctx)
 void
 oscore_roll_back_seq(oscore_recipient_ctx_t *ctx)
 {
+  LOG_DBG("Rolling back seq (window %"PRIu32" = %"PRIi32") (seq %"PRIi64" = %"PRIi64")\n",
+    ctx->sliding_window, ctx->rollback_sliding_window,
+    ctx->largest_seq, ctx->rollback_largest_seq);
+
  // if(ctx->rollback_sliding_window != -1){
     ctx->sliding_window = ctx->rollback_sliding_window;
  //   ctx->rollback_sliding_window = -1;

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -51,13 +51,11 @@
 #define LOG_LEVEL LOG_LEVEL_COAP
 
 void
-printf_hex(const uint8_t *data, unsigned int len)
+printf_hex(const uint8_t *data, size_t len)
 {
-  unsigned int i = 0;
-  for(i = 0; i < len; i++) {
-    LOG_DBG_("%02x ", data[i]);
+  for(size_t i = 0; i < len; i++) {
+    LOG_ERR_("%02x", data[i]);
   }
-  LOG_DBG_("\n");
 }
 static bool
 coap_is_request(const coap_message_t *coap_pkt)
@@ -65,22 +63,16 @@ coap_is_request(const coap_message_t *coap_pkt)
   return coap_pkt->code >= COAP_GET && coap_pkt->code <= COAP_DELETE;
 }
 bool
-oscore_protected_request(void *request)
+oscore_protected_request(const coap_message_t *request)
 {
-  if(request != NULL) {
-    coap_message_t *coap_pkt = (coap_message_t *)request;
-    if(coap_is_option(coap_pkt, COAP_OPTION_OSCORE)) {
-      return true;
-    }
-  }
-  return false;
+  return request != NULL && coap_is_option(request, COAP_OPTION_OSCORE);
 }
 void
 oscore_protect_resource(coap_resource_t *resource)
 {
   resource->oscore_protected = 1;
 }
-bool oscore_is_resource_protected(coap_resource_t *resource)
+bool oscore_is_resource_protected(const coap_resource_t *resource)
 {
   return resource->oscore_protected;
 }
@@ -107,7 +99,7 @@ uint64_t
 btou64(uint8_t *bytes, size_t len)
 {
   uint8_t buffer[8];
-  memset(buffer, 0, 8); /* function variables are not initializated to anything */
+  memset(buffer, 0, sizeof(buffer)); /* function variables are not initializated to anything */
   int offset = 8 - len;
   uint64_t num;
 
@@ -162,7 +154,7 @@ oscore_decode_option_value(uint8_t *option_value, int option_len, cose_encrypt0_
 {
   
   if(option_len == 0){
-        return NO_ERROR;
+    return NO_ERROR;
   } else if( option_len > 255 || option_len < 0 || (option_value[0] & 0x06) == 6 || (option_value[0] & 0x07) == 7 || (option_value[0] & 0xE0) != 0) {
     return BAD_OPTION_4_02;
   }
@@ -208,24 +200,26 @@ oscore_decode_message(coap_message_t *coap_pkt)
   uint8_t nonce_buffer[COSE_algorithm_AES_CCM_16_64_128_IV_LEN];
   cose_encrypt0_init(cose);
   /* Options are discarded later when they are overwritten. This should be improved */
-	  coap_status_t ret = oscore_decode_option_value(coap_pkt->object_security, coap_pkt->object_security_len, cose);
-  if( ret != NO_ERROR){
-	 LOG_DBG_("OSCORE option value could not be parsed.\n");
-	 coap_error_message = "OSCORE option could not be parsed.";
-	 return ret;
+  coap_status_t ret = oscore_decode_option_value(coap_pkt->object_security, coap_pkt->object_security_len, cose);
+  if(ret != NO_ERROR){
+    LOG_ERR("OSCORE option value could not be parsed.\n");
+    coap_error_message = "OSCORE option could not be parsed.";
+    return ret;
   }
   if(coap_is_request(coap_pkt)) {
     const uint8_t *key_id;
     uint8_t key_id_len = cose_encrypt0_get_key_id(cose, &key_id);
     ctx = oscore_find_ctx_by_rid(key_id, key_id_len);
     if(ctx == NULL) {
-      LOG_DBG_("OSCORE Security Context not found.\n");
+      LOG_ERR("OSCORE Security Context not found (rid = '");
+      printf_hex(key_id, key_id_len);
+      LOG_ERR_("' len=%u).\n", key_id_len);
       coap_error_message = "Security context not found";
-      return UNAUTHORIZED_4_01;
+      return OSCORE_MISSING_CONTEXT;//UNAUTHORIZED_4_01;
     }
     /*4 Verify the ‘Partial IV’ parameter using the Replay Window, as described in Section 7.4. */
     if(!oscore_validate_sender_seq(&ctx->recipient_context, cose)) {
-      LOG_DBG_("OSCORE Replayed or old message\n");
+      LOG_WARN("OSCORE Replayed or old message\n");
       coap_error_message = "Replay detected";
       return UNAUTHORIZED_4_01;
     }
@@ -233,11 +227,13 @@ oscore_decode_message(coap_message_t *coap_pkt)
   } else { /* Message is a response */
     uint64_t seq;
     uint8_t seq_buffer[8];
-    ctx = oscore_get_exchange(coap_pkt->token, coap_pkt->token_len, &seq);
+    ctx = oscore_get_contex_from_exchange(coap_pkt->token, coap_pkt->token_len, &seq);
     if(ctx == NULL) {
-      LOG_DBG_("OSCORE Security Context not found.\n");
+      LOG_ERR("OSCORE Security Context not found (token = '");
+      printf_hex(coap_pkt->token, coap_pkt->token_len);
+      LOG_ERR_("' len=%u).\n", coap_pkt->token_len);
       coap_error_message = "Security context not found";
-      return UNAUTHORIZED_4_01;
+      return OSCORE_MISSING_CONTEXT;//UNAUTHORIZED_4_01;
     }
     /* If message contains a partial IV, the received is used. */
     if(cose->partial_iv_len == 0){
@@ -245,10 +241,10 @@ oscore_decode_message(coap_message_t *coap_pkt)
       cose_encrypt0_set_partial_iv(cose, seq_buffer, seq_len);
     }
   }
-  oscore_populate_cose(coap_pkt, cose, ctx, 0);  
+  oscore_populate_cose(coap_pkt, cose, ctx, false);
   coap_pkt->security_context = ctx;
 
-  size_t aad_len = oscore_prepare_aad(coap_pkt, cose, aad_buffer, 0);
+  size_t aad_len = oscore_prepare_aad(coap_pkt, cose, aad_buffer, false);
   cose_encrypt0_set_aad(cose, aad_buffer, aad_len);
   cose_encrypt0_set_alg(cose, ctx->alg);
   
@@ -258,7 +254,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
   cose_encrypt0_set_content(cose, coap_pkt->payload, coap_pkt->payload_len);
   int res = cose_encrypt0_decrypt(cose);
   if(res <= 0) {
-    LOG_DBG_("OSCORE Decryption Failure, result code: %d\n", res);
+    LOG_ERR("OSCORE Decryption Failure, result code: %d\n", res);
     if(coap_is_request(coap_pkt)) {
       oscore_roll_back_seq(&ctx->recipient_context);
       coap_error_message = "Decryption failure";
@@ -273,8 +269,8 @@ oscore_decode_message(coap_message_t *coap_pkt)
   return status;
 }
 
-uint8_t
-oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, uint8_t sending)
+void
+oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, bool sending)
 {
   cose_encrypt0_set_alg(cose, ctx->alg);
 
@@ -304,8 +300,6 @@ oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *c
       cose_encrypt0_set_key(cose, ctx->recipient_context.recipient_key, COSE_algorithm_AES_CCM_16_64_128_KEY_LEN);
     }
   }
-
-  return 0;
 }
 
 /* Prepares a new OSCORE message, returns the size of the message. */
@@ -318,23 +312,23 @@ oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer)
   uint8_t aad_buffer[35];
   uint8_t nonce_buffer[COSE_algorithm_AES_CCM_16_64_128_IV_LEN];
   uint8_t option_value_buffer[15];
-/*  1 Retrieve the Sender Context associated with the target resource. */
+  /*  1 Retrieve the Sender Context associated with the target resource. */
   oscore_ctx_t *ctx = coap_pkt->security_context;
   if(ctx == NULL) {
-    LOG_DBG_("No context in OSCORE!\n");
+    LOG_ERR("No context in OSCORE!\n");
     return PACKET_SERIALIZATION_ERROR;
   }
-  oscore_populate_cose(coap_pkt, cose, coap_pkt->security_context, 1);
+  oscore_populate_cose(coap_pkt, cose, coap_pkt->security_context, true);
 
   uint8_t plaintext_len = oscore_serializer(coap_pkt, content_buffer, ROLE_CONFIDENTIAL);
-  if( plaintext_len > COAP_MAX_CHUNK_SIZE){
-    LOG_DBG_("OSCORE Message to large to process.\n");
+  if(plaintext_len > COAP_MAX_CHUNK_SIZE){
+    LOG_ERR("OSCORE Message to large to process.\n");
     return PACKET_SERIALIZATION_ERROR;
   }
 
   cose_encrypt0_set_content(cose, content_buffer, plaintext_len);
   
-  uint8_t aad_len = oscore_prepare_aad(coap_pkt, cose, aad_buffer, 1);
+  uint8_t aad_len = oscore_prepare_aad(coap_pkt, cose, aad_buffer, true);
   cose_encrypt0_set_aad(cose, aad_buffer, aad_len);
   
   oscore_generate_nonce(cose, coap_pkt, nonce_buffer, COSE_algorithm_AES_CCM_16_64_128_IV_LEN);
@@ -342,24 +336,23 @@ oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer)
   
   if(coap_is_request(coap_pkt)){
     if(!oscore_set_exchange(coap_pkt->token, coap_pkt->token_len, ctx->sender_context.seq, ctx)){
-	LOG_DBG_("OSCORE Could not store exchange.\n");
+      LOG_ERR("OSCORE Could not store exchange.\n");
     	return PACKET_SERIALIZATION_ERROR;
     }
     oscore_increment_sender_seq(ctx);
   }
   int ciphertext_len = cose_encrypt0_encrypt(cose);
-  if( ciphertext_len < 0){
-    LOG_DBG_("OSCORE internal error %d.\n", ciphertext_len);
+  if(ciphertext_len < 0){
+    LOG_ERR("OSCORE internal error %d.\n", ciphertext_len);
     return PACKET_SERIALIZATION_ERROR;
   }
   
   uint8_t option_value_len = 0;
   if(coap_is_request(coap_pkt)){
-	option_value_len = oscore_encode_option_value(option_value_buffer, cose, 1);
+    option_value_len = oscore_encode_option_value(option_value_buffer, cose, 1);
   } else { //Partial IV shall NOT be included in responses
-	option_value_len = oscore_encode_option_value(option_value_buffer, cose, 0);
+    option_value_len = oscore_encode_option_value(option_value_buffer, cose, 0);
   }
-
   
   coap_set_payload(coap_pkt, content_buffer, ciphertext_len);
   coap_set_header_object_security(coap_pkt, option_value_buffer, option_value_len);
@@ -377,7 +370,7 @@ oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer)
 }
 /* Creates and sets External AAD */
 size_t
-oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buffer, uint8_t sending)
+oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buffer, bool sending)
 {
   uint8_t external_aad_buffer[25];
   uint8_t *external_aad_ptr = external_aad_buffer;
@@ -388,23 +381,24 @@ oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buf
   external_aad_len += cbor_put_array(&external_aad_ptr, 1); /* Algoritms array */
   external_aad_len += cbor_put_unsigned(&external_aad_ptr, (coap_pkt->security_context->alg)); /* Algorithm */
   /*When sending responses. */
-  if( !coap_is_request(coap_pkt)) { 
-    external_aad_len += cbor_put_bytes(&external_aad_ptr, coap_pkt->security_context->recipient_context.recipient_id,  coap_pkt->security_context->recipient_context.recipient_id_len);
+  if(!coap_is_request(coap_pkt)) {
+    external_aad_len += cbor_put_bytes(&external_aad_ptr,
+      coap_pkt->security_context->recipient_context.recipient_id,
+      coap_pkt->security_context->recipient_context.recipient_id_len);
   } else {	 
     external_aad_len += cbor_put_bytes(&external_aad_ptr, cose->key_id, cose->key_id_len);
   }
   external_aad_len += cbor_put_bytes(&external_aad_ptr, cose->partial_iv, cose->partial_iv_len);  
   external_aad_len += cbor_put_bytes(&external_aad_ptr, NULL, 0); /* Put integrety protected option, at present there are none. */
- 
+
   uint8_t ret = 0;
-  char* encrypt0 = "Encrypt0";
+  const char* encrypt0 = "Encrypt0";
   /* Begin creating the AAD */
   ret += cbor_put_array(&buffer, 3);
   ret += cbor_put_text(&buffer, encrypt0, strlen(encrypt0));
   ret += cbor_put_bytes(&buffer, NULL, 0);
   ret += cbor_put_bytes(&buffer, external_aad_buffer, external_aad_len);  
 
- 
   return ret;
 }
 /* Creates Nonce */
@@ -449,7 +443,7 @@ oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose)
 {
   int64_t incomming_seq = btou64(cose->partial_iv, cose->partial_iv_len);
 //todo add LOG_DBG here 
-  LOG_DBG_("Incomming SEQ %" PRIi64 "\n", incomming_seq);
+  LOG_DBG("Incomming SEQ %" PRIi64 "\n", incomming_seq);
   ctx->rollback_largest_seq = ctx->largest_seq;
   ctx->rollback_sliding_window = ctx->sliding_window;
 
@@ -498,16 +492,11 @@ oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose)
   return 1;
 }
 /* Return 0 if SEQ MAX, return 1 if OK */
-uint8_t
+bool
 oscore_increment_sender_seq(oscore_ctx_t *ctx)
 {
   ctx->sender_context.seq++;
-
-  if(ctx->sender_context.seq >= OSCORE_SEQ_MAX) {
-    return 0;
-  } else {
-    return 1;
-  }
+  return ctx->sender_context.seq < OSCORE_SEQ_MAX;
 }
 /* Restore the sequence number and replay-window to the previous state. This is to be used when decryption fail. */
 void

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -229,6 +229,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
     uint64_t seq;
     uint8_t seq_buffer[8];
     ctx = oscore_get_contex_from_exchange(coap_pkt->token, coap_pkt->token_len, &seq);
+    oscore_remove_exchange(coap_pkt->token, coap_pkt->token_len);
     if(ctx == NULL) {
       LOG_ERR("OSCORE Security Context not found (token = '");
       printf_hex(coap_pkt->token, coap_pkt->token_len);

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -216,7 +216,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
       printf_hex(key_id, key_id_len);
       LOG_ERR_("' len=%u).\n", key_id_len);
       coap_error_message = "Security context not found";
-      return OSCORE_MISSING_CONTEXT;//UNAUTHORIZED_4_01;
+      return OSCORE_MISSING_CONTEXT; /* Will transform into UNAUTHORIZED_4_01 later */
     }
     /*4 Verify the ‘Partial IV’ parameter using the Replay Window, as described in Section 7.4. */
     if(!oscore_validate_sender_seq(&ctx->recipient_context, cose)) {
@@ -235,7 +235,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
       printf_hex(coap_pkt->token, coap_pkt->token_len);
       LOG_ERR_("' len=%u).\n", coap_pkt->token_len);
       coap_error_message = "Security context not found";
-      return OSCORE_MISSING_CONTEXT;//UNAUTHORIZED_4_01;
+      return OSCORE_MISSING_CONTEXT; /* Will transform into UNAUTHORIZED_4_01 later */
     }
     /* If message contains a partial IV, the received is used. */
     if(cose->partial_iv_len == 0){

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -77,7 +77,7 @@ bool oscore_is_resource_protected(const coap_resource_t *resource)
 {
   return resource->oscore_protected;
 }
-uint8_t
+static uint8_t
 u64tob(uint64_t value, uint8_t *buffer)
 {
   memset(buffer, 0, 8);
@@ -96,7 +96,7 @@ u64tob(uint64_t value, uint8_t *buffer)
   return length == 0 ? 1 : length;
 
 }
-uint64_t
+static uint64_t
 btou64(uint8_t *bytes, size_t len)
 {
   uint8_t buffer[8];
@@ -153,7 +153,6 @@ oscore_encode_option_value(uint8_t *option_buffer, cose_encrypt0_t *cose, uint8_
 coap_status_t
 oscore_decode_option_value(uint8_t *option_value, int option_len, cose_encrypt0_t *cose)
 {
-  
   if(option_len == 0){
     return NO_ERROR;
   } else if( option_len > 255 || option_len < 0 || (option_value[0] & 0x06) == 6 || (option_value[0] & 0x07) == 7 || (option_value[0] & 0xE0) != 0) {
@@ -381,7 +380,7 @@ oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buf
   external_aad_len += cbor_put_array(&external_aad_ptr, 5);
   external_aad_len += cbor_put_unsigned(&external_aad_ptr, 1); /* Version, always for this version of the draft 1 */
   external_aad_len += cbor_put_array(&external_aad_ptr, 1); /* Algorithms array */
-  external_aad_len += cbor_put_unsigned(&external_aad_ptr, (coap_pkt->security_context->alg)); /* Algorithm */
+  external_aad_len += cbor_put_unsigned(&external_aad_ptr, coap_pkt->security_context->alg); /* Algorithm */
   /*When sending responses. */
   if(coap_is_request(coap_pkt)) {
     external_aad_len += cbor_put_bytes(&external_aad_ptr, cose->key_id, cose->key_id_len);
@@ -398,6 +397,8 @@ oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buf
   }
   external_aad_len += cbor_put_bytes(&external_aad_ptr, cose->partial_iv, cose->partial_iv_len);  
   external_aad_len += cbor_put_bytes(&external_aad_ptr, NULL, 0); /* Put integrety protected option, at present there are none. */
+
+  assert(external_aad_len <= sizeof(external_aad_buffer));
 
   uint8_t ret = 0;
   const char* encrypt0 = "Encrypt0";

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -522,17 +522,15 @@ oscore_roll_back_seq(oscore_recipient_ctx_t *ctx)
 //    ctx->rollback_largest_seq = -1;
 //  }
 }
-/* Initialize the security_context storage and the protected resource storage. */
+
 void
-oscore_init_server()
+oscore_init(void)
 {
   oscore_ctx_store_init();
+
+  /* Initialize the security_context storage and the protected resource storage. */
   oscore_exchange_store_init();
-}
-/* Initialize the security_context storage, the token - seq association storrage and the URI - security_context association storage. */
-void
-oscore_init_client()
-{
-  oscore_ctx_store_init();
+
+  /* Initialize the security_context storage, the token - seq association storrage and the URI - security_context association storage. */
   oscore_ep_ctx_store_init();
 }

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -84,9 +84,6 @@ void oscore_roll_back_seq(oscore_recipient_ctx_t *ctx);
 uint8_t oscore_cose_compress(cose_encrypt0_t *cose, uint8_t *buffer);
 uint8_t oscore_cose_decompress(cose_encrypt0_t *cose, uint8_t *buffer, size_t buffer_len);
 
-/* Start protected resource storage. */
-void oscore_protected_resource_store_init();
-
 /* Mark a resource as protected by OSCORE, incoming COAP requests to that resource will be rejected. */
 void oscore_protect_resource(coap_resource_t *resource);
 

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -96,7 +96,4 @@ bool oscore_protected_request(const coap_message_t *request);
 /* Initialize the context storage, the token - seq association storrage and the URI - context association storage. */
 void oscore_init(void);
 
-/* TEMP */
-void printf_hex(const uint8_t *data, size_t len);
-
 #endif /* _OSCORE_H */

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -63,9 +63,6 @@ coap_status_t oscore_decode_option_value(uint8_t *option_value, int option_len, 
 /* Prepares a new OSCORE message, returns the size of the message. */
 size_t oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer);
 
-/*Sets Alg, Partial IV Key ID and Key in COSE. Returns status*/
-void oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, bool sending);
-
 /* Creates AAD, creates External AAD and serializes it into the complete AAD structure. Returns serialized size. */
 size_t oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buffer, bool sending);
 /* Creates Nonce */
@@ -75,7 +72,7 @@ void oscore_generate_nonce(cose_encrypt0_t *ptr, coap_message_t *coap_pkt, uint8
 void oscore_clear_options(coap_message_t *ptr);
 
 /*Return 1 if OK, Error code otherwise */
-uint8_t oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose);
+bool oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose);
 
 /* Return 0 if SEQ MAX, return 1 if OK */
 bool oscore_increment_sender_seq(oscore_ctx_t *ctx);

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -64,10 +64,10 @@ coap_status_t oscore_decode_option_value(uint8_t *option_value, int option_len, 
 size_t oscore_prepare_message(coap_message_t *coap_pkt, uint8_t *buffer);
 
 /*Sets Alg, Partial IV Key ID and Key in COSE. Returns status*/
-uint8_t oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, uint8_t sending);
+void oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, bool sending);
 
 /* Creates AAD, creates External AAD and serializes it into the complete AAD structure. Returns serialized size. */
-size_t oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buffer, uint8_t sending);
+size_t oscore_prepare_aad(coap_message_t *coap_pkt, cose_encrypt0_t *cose, uint8_t *buffer, bool sending);
 /* Creates Nonce */
 void oscore_generate_nonce(cose_encrypt0_t *ptr, coap_message_t *coap_pkt, uint8_t *buffer, uint8_t size);
 
@@ -78,7 +78,7 @@ void oscore_clear_options(coap_message_t *ptr);
 uint8_t oscore_validate_sender_seq(oscore_recipient_ctx_t *ctx, cose_encrypt0_t *cose);
 
 /* Return 0 if SEQ MAX, return 1 if OK */
-uint8_t oscore_increment_sender_seq(oscore_ctx_t *ctx);
+bool oscore_increment_sender_seq(oscore_ctx_t *ctx);
 
 /* Restore the sequence number and replay-window to the previous state. This is to be used when decryption fail. */
 void oscore_roll_back_seq(oscore_recipient_ctx_t *ctx);
@@ -89,9 +89,9 @@ uint8_t oscore_cose_decompress(cose_encrypt0_t *cose, uint8_t *buffer, size_t bu
 
 /* Mark a resource as protected by OSCORE, incoming COAP requests to that resource will be rejected. */
 void oscore_protect_resource(coap_resource_t *resource);
-bool oscore_is_resource_protected(coap_resource_t *resource);
+bool oscore_is_resource_protected(const coap_resource_t *resource);
 
-bool oscore_protected_request(void *request);
+bool oscore_protected_request(const coap_message_t *request);
 /*Retuns 1 if the resource is protected by OSCORE, 0 otherwise. */
 
 
@@ -100,6 +100,6 @@ bool oscore_protected_request(void *request);
 void oscore_init(void);
 
 /* TEMP */
-void printf_hex(const uint8_t *data, unsigned int len);
+void printf_hex(const uint8_t *data, size_t len);
 
 #endif /* _OSCORE_H */

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -45,6 +45,9 @@
 #include "oscore-context.h"
 #include "coap-engine.h"
 
+#include <stdbool.h>
+#include <stdint.h>
+
 #define OSCORE_DEFAULT_REPLAY_WINDOW 32
 
 size_t oscore_serializer(coap_message_t *coap_pkt, uint8_t *buffer, uint8_t role);
@@ -86,16 +89,17 @@ uint8_t oscore_cose_decompress(cose_encrypt0_t *cose, uint8_t *buffer, size_t bu
 
 /* Mark a resource as protected by OSCORE, incoming COAP requests to that resource will be rejected. */
 void oscore_protect_resource(coap_resource_t *resource);
+bool oscore_is_resource_protected(coap_resource_t *resource);
 
-uint8_t oscore_protected_request(void *request);
+bool oscore_protected_request(void *request);
 /*Retuns 1 if the resource is protected by OSCORE, 0 otherwise. */
-uint8_t oscore_is_resource_protected(char uri);
+
 
 /* Initialize the context storage and the protected resource storage. */
 /* Initialize the context storage, the token - seq association storrage and the URI - context association storage. */
 void oscore_init(void);
 
 /* TEMP */
-void printf_hex(unsigned char *data, unsigned int len);
+void printf_hex(const uint8_t *data, unsigned int len);
 
 #endif /* _OSCORE_H */

--- a/os/net/app-layer/coap/oscore-support/oscore.h
+++ b/os/net/app-layer/coap/oscore-support/oscore.h
@@ -92,10 +92,8 @@ uint8_t oscore_protected_request(void *request);
 uint8_t oscore_is_resource_protected(char uri);
 
 /* Initialize the context storage and the protected resource storage. */
-void oscore_init_server();
-
 /* Initialize the context storage, the token - seq association storrage and the URI - context association storage. */
-void oscore_init_client();
+void oscore_init(void);
 
 /* TEMP */
 void printf_hex(unsigned char *data, unsigned int len);

--- a/tests/20-oscore/code-oscore/context.c
+++ b/tests/20-oscore/code-oscore/context.c
@@ -95,16 +95,16 @@ UNIT_TEST(test_exchange_storage){
   UNIT_TEST_ASSERT(ret == 1);
   
   uint64_t seq_1_ptr; 
-  oscore_ctx_t *ctx_ptr_1 = oscore_get_exchange(token_1, 4, &seq_1_ptr);
+  oscore_ctx_t *ctx_ptr_1 = oscore_get_contex_from_exchange(token_1, 4, &seq_1_ptr);
   UNIT_TEST_ASSERT(ctx_ptr_1 == ctx_1);
 
   uint64_t seq_2_ptr; 
-  oscore_ctx_t *ctx_ptr_2 = oscore_get_exchange(token_2, 5, &seq_2_ptr);
+  oscore_ctx_t *ctx_ptr_2 = oscore_get_contex_from_exchange(token_2, 5, &seq_2_ptr);
   UNIT_TEST_ASSERT(ctx_ptr_2 == ctx_2);
    
     /* Test to fetch non-existing exchange. */
   oscore_remove_exchange(token_1, 4);
-  ctx_ptr_1 = oscore_get_exchange(token_1, 4, &seq_1_ptr);
+  ctx_ptr_1 = oscore_get_contex_from_exchange(token_1, 4, &seq_1_ptr);
   UNIT_TEST_ASSERT(ctx_ptr_1 == NULL);
   UNIT_TEST_ASSERT(seq_1_ptr == 0); 
  
@@ -112,10 +112,10 @@ UNIT_TEST(test_exchange_storage){
   UNIT_TEST_ASSERT(ret == 1);
 
   uint64_t seq_3_ptr;
-  oscore_ctx_t *ctx_ptr_3 = oscore_get_exchange(token_3, 1, &seq_3_ptr);
+  oscore_ctx_t *ctx_ptr_3 = oscore_get_contex_from_exchange(token_3, 1, &seq_3_ptr);
   UNIT_TEST_ASSERT( ctx_ptr_3 == ctx_3);
  
-  ctx_ptr_2 = oscore_get_exchange(token_2, 5, &seq_2_ptr);
+  ctx_ptr_2 = oscore_get_contex_from_exchange(token_2, 5, &seq_2_ptr);
   UNIT_TEST_ASSERT(ctx_ptr_2 == ctx_2);
   
 
@@ -123,11 +123,11 @@ UNIT_TEST(test_exchange_storage){
   oscore_remove_exchange(token_2, 5);
   oscore_remove_exchange(token_3, 1);
 
-  ctx_ptr_1 = oscore_get_exchange(token_1, 4, &seq_1_ptr);
+  ctx_ptr_1 = oscore_get_contex_from_exchange(token_1, 4, &seq_1_ptr);
   UNIT_TEST_ASSERT( ctx_ptr_1 == 0);
-  ctx_ptr_2 = oscore_get_exchange(token_2, 5, &seq_2_ptr);
+  ctx_ptr_2 = oscore_get_contex_from_exchange(token_2, 5, &seq_2_ptr);
   UNIT_TEST_ASSERT( ctx_ptr_2 == 0);
-  ctx_ptr_3 = oscore_get_exchange(token_3, 1, &seq_3_ptr);
+  ctx_ptr_3 = oscore_get_contex_from_exchange(token_3, 1, &seq_3_ptr);
   UNIT_TEST_ASSERT( ctx_ptr_3 == 0);
 
   UNIT_TEST_END();


### PR DESCRIPTION
This PR provides various improvements to the OSCORE implementation, including:

1. Allowing users to manage the memory allocation of OSCORE contexts
2. Using a separate log level for OSCORE (instead of using the same log level as CoAP)
3. Support for using the coap-callback-api with OSCORE
4. Simplifying the initialisation of OSCORE, so users do not need to manually initialise OSCORE
5. Allowing users to be notified when a context is not present, so one can be created if appropriate
6. Greater use of `const` where appropriate
7. A bug fix regarding the kid used in `oscore_prepare_aad` (by Martin Gunnarsson)
8. A bug fix to avoid use of out-of-scope buffers in `oscore_populate_cose` (proposed by Martin Gunnarsson)

Please note that as part of the implementation of point 5, a 401 response code is no longer sent when a context could not be found to decrypt a message. This needs to be revised in a later PR.