### PR TITLE
OSCORE: Use LOG_*_BYTES for debug logging of byte arrays

### DIFF
--- a/os/net/app-layer/coap/oscore-support/oscore-crypto.c
+++ b/os/net/app-layer/coap/oscore-support/oscore-crypto.c
@@ -62,9 +62,7 @@ static void
 printf_hex(const char *name, const uint8_t *data, unsigned int len)
 {
   LOG_DBG("%s (len=%u): ", name, len);
-  for(unsigned int i = 0; i < len; i++) {
-    LOG_DBG_("%02x", data[i]);
-  }
+  LOG_DBG_BYTES(data, len);
   LOG_DBG_("\n");
 }
 #endif

--- a/os/net/app-layer/coap/oscore-support/oscore.c
+++ b/os/net/app-layer/coap/oscore-support/oscore.c
@@ -59,19 +59,10 @@
 static void oscore_populate_cose(coap_message_t *pkt, cose_encrypt0_t *cose, oscore_ctx_t *ctx, bool sending, uint8_t partial_iv_buffer[8]);
 
 static void
-printf_hex(const uint8_t *data, size_t len)
-{
-  for(size_t i = 0; i < len; i++) {
-    LOG_ERR_("%02x", data[i]);
-  }
-}
-static void
 printf_hex_detailed(const char* name, const uint8_t *data, size_t len)
 {
-  LOG_DBG("%s (len=%u): ", name, len);
-  for(size_t i = 0; i < len; i++) {
-    LOG_DBG_("%02x", data[i]);
-  }
+  LOG_DBG("%s (len=%zu): ", name, len);
+  LOG_DBG_BYTES(data, len);
   LOG_DBG_("\n");
 }
 
@@ -234,7 +225,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
     ctx = oscore_find_ctx_by_rid(key_id, key_id_len);
     if(ctx == NULL) {
       LOG_ERR("OSCORE Security Context not found (rid = '");
-      printf_hex(key_id, key_id_len);
+      LOG_ERR_BYTES(key_id, key_id_len);
       LOG_ERR_("' len=%u).\n", key_id_len);
       coap_error_message = "Security context not found";
       return OSCORE_MISSING_CONTEXT; /* Will transform into UNAUTHORIZED_4_01 later */
@@ -252,7 +243,7 @@ oscore_decode_message(coap_message_t *coap_pkt)
     oscore_remove_exchange(coap_pkt->token, coap_pkt->token_len);
     if(ctx == NULL) {
       LOG_ERR("OSCORE Security Context not found (token = '");
-      printf_hex(coap_pkt->token, coap_pkt->token_len);
+      LOG_ERR_BYTES(coap_pkt->token, coap_pkt->token_len);
       LOG_ERR_("' len=%u).\n", coap_pkt->token_len);
       coap_error_message = "Security context not found";
       return OSCORE_MISSING_CONTEXT; /* Will transform into UNAUTHORIZED_4_01 later */

--- a/tests/20-oscore/code-oscore/context.c
+++ b/tests/20-oscore/code-oscore/context.c
@@ -22,13 +22,6 @@ test_setup(void)
   oscore_init_client();
 }
 
-void t_printf_hex(uint8_t *hex, int len){
-	for ( int i = 0; i < len; i++){
-		printf("%02X ", hex[i]);
-	}
-	printf("\n");
-}
-
 UNIT_TEST_REGISTER(test_client_context_derivation,
                    "context_derivation()");
 UNIT_TEST(test_client_context_derivation)

--- a/tests/20-oscore/code-oscore/oscore-test.c
+++ b/tests/20-oscore/code-oscore/oscore-test.c
@@ -23,13 +23,6 @@ test_setup(void)
   oscore_init_client();
 }
 
-void t_printf_hex(uint8_t *hex, int len){
-	for ( int i = 0; i < len; i++){
-		printf("%02X ", hex[i]);
-	}
-	printf("\n");
-}
-
 UNIT_TEST_REGISTER(test_validate_sender_seq,
                    "validate_sender_seq()");
 UNIT_TEST(test_validate_sender_seq)


### PR DESCRIPTION
This PR implements logging of byte arrays using new LOG_*_BYTES macros defined in https://github.com/contiki-ng/contiki-ng/pull/1300